### PR TITLE
[SIDE-913] Update Makefiles, Add Windows back to Linter

### DIFF
--- a/.github/workflows/golintci.yml
+++ b/.github/workflows/golintci.yml
@@ -14,7 +14,7 @@ jobs:
         go-version: [1.15.x]
         os:
           - macos-latest
-          # - windows-latest
+          - windows-latest
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,4 +25,5 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.32
           args: --timeout=10m
+          # Only the LDK is checked; does not appear to check examples.
           working-directory: ldk/go

--- a/ldk/go/examples/clipboard/Makefile
+++ b/ldk/go/examples/clipboard/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/filesystem-directory/Makefile
+++ b/ldk/go/examples/filesystem-directory/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/filesystem-file/Makefile
+++ b/ldk/go/examples/filesystem-file/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/filesystem-listen-directory/Makefile
+++ b/ldk/go/examples/filesystem-listen-directory/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/filesystem-listen-file/Makefile
+++ b/ldk/go/examples/filesystem-listen-file/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/keyboard-character/Makefile
+++ b/ldk/go/examples/keyboard-character/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: Remove before merging to master branch
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/keyboard-hotkey/Makefile
+++ b/ldk/go/examples/keyboard-hotkey/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: Remove before merging to master branch
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/keyboard/Makefile
+++ b/ldk/go/examples/keyboard/Makefile
@@ -35,7 +35,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/go/examples/whisper-markdown/Makefile
+++ b/ldk/go/examples/whisper-markdown/Makefile
@@ -29,7 +29,7 @@ build: clean build/darwin-amd64/plugin build/windows-amd64/plugin
 
 # TODO: remove before merging to master
 deploy-local: build
-	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Sidekick/loops/1/plugin
+	cp build/darwin-amd64/plugin ~/Library/Application\ Support/Olive\ Helps/loops/1/plugin
 
 test:
 	go test -v ./...

--- a/ldk/node/docs/classes/logger.html
+++ b/ldk/node/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L27">logging.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L27">logging.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L114">logging.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L114">logging.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L177">logging.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L177">logging.ts:177</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L135">logging.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L135">logging.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L93">logging.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L93">logging.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L156">logging.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L156">logging.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L71">logging.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/logging.ts#L71">logging.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/classes/logger.html
+++ b/ldk/node/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L27">logging.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L27">logging.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L114">logging.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L114">logging.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L177">logging.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L177">logging.ts:177</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L135">logging.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L135">logging.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L93">logging.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L93">logging.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L156">logging.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L156">logging.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/logging.ts#L71">logging.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/logging.ts#L71">logging.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/classes/plugin.html
+++ b/ldk/node/docs/classes/plugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/plugin.ts#L15">plugin.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/plugin.ts#L15">plugin.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/plugin.ts#L38">plugin.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/plugin.ts#L38">plugin.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/classes/plugin.html
+++ b/ldk/node/docs/classes/plugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/plugin.ts#L15">plugin.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/plugin.ts#L15">plugin.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/plugin.ts#L38">plugin.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/plugin.ts#L38">plugin.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/enums/access.html
+++ b/ldk/node/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/access.html
+++ b/ldk/node/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/category.html
+++ b/ldk/node/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/category.html
+++ b/ldk/node/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/filesystemstreamaction.html
+++ b/ldk/node/docs/enums/filesystemstreamaction.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Chmod<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;chmod&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L50">hostClients/fileSystemService.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L50">hostClients/fileSystemService.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;create&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L46">hostClients/fileSystemService.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L46">hostClients/fileSystemService.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;remove&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L48">hostClients/fileSystemService.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L48">hostClients/fileSystemService.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rename<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;rename&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L49">hostClients/fileSystemService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L49">hostClients/fileSystemService.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L45">hostClients/fileSystemService.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L45">hostClients/fileSystemService.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">Write<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;write&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L47">hostClients/fileSystemService.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L47">hostClients/fileSystemService.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/filesystemstreamaction.html
+++ b/ldk/node/docs/enums/filesystemstreamaction.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Chmod<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;chmod&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L50">hostClients/fileSystemService.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L50">hostClients/fileSystemService.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;create&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L46">hostClients/fileSystemService.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L46">hostClients/fileSystemService.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;remove&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L48">hostClients/fileSystemService.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L48">hostClients/fileSystemService.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rename<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;rename&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L49">hostClients/fileSystemService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L49">hostClients/fileSystemService.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L45">hostClients/fileSystemService.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L45">hostClients/fileSystemService.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">Write<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;write&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L47">hostClients/fileSystemService.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L47">hostClients/fileSystemService.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/operatingsystem.html
+++ b/ldk/node/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/operatingsystem.html
+++ b/ldk/node/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/processstreamaction.html
+++ b/ldk/node/docs/enums/processstreamaction.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;started&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L6">hostClients/processService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L6">hostClients/processService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;stopped&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L7">hostClients/processService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L7">hostClients/processService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L5">hostClients/processService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L5">hostClients/processService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/processstreamaction.html
+++ b/ldk/node/docs/enums/processstreamaction.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;started&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L6">hostClients/processService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L6">hostClients/processService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;stopped&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L7">hostClients/processService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L7">hostClients/processService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L5">hostClients/processService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L5">hostClients/processService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/windowstreamaction.html
+++ b/ldk/node/docs/enums/windowstreamaction.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Closed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;closed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L19">hostClients/windowService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L19">hostClients/windowService.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Focused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;focused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L16">hostClients/windowService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L16">hostClients/windowService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Opened<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;opened&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L18">hostClients/windowService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L18">hostClients/windowService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unfocused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unfocused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L17">hostClients/windowService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L17">hostClients/windowService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L15">hostClients/windowService.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L15">hostClients/windowService.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/windowstreamaction.html
+++ b/ldk/node/docs/enums/windowstreamaction.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Closed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;closed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L19">hostClients/windowService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L19">hostClients/windowService.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Focused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;focused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L16">hostClients/windowService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L16">hostClients/windowService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Opened<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;opened&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L18">hostClients/windowService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L18">hostClients/windowService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unfocused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unfocused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L17">hostClients/windowService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L17">hostClients/windowService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L15">hostClients/windowService.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L15">hostClients/windowService.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/globals.html
+++ b/ldk/node/docs/globals.html
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">Form<wbr>Message&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>setLabel<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>setTooltip<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">hostClients/whisperMessageBuilder.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">hostClients/whisperMessageBuilder.ts:11</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -205,7 +205,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">hostClients/whisperMessageBuilder.ts:12</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">hostClients/whisperMessageBuilder.ts:12</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -227,7 +227,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">hostClients/whisperMessageBuilder.ts:13</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">hostClients/whisperMessageBuilder.ts:13</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Listener&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, input<span class="tsd-signature-symbol">?: </span><a href="" class="tsd-signature-type">T</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/stoppableStream.ts#L8">hostClients/stoppableStream.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L8">hostClients/stoppableStream.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Checkbox<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"checkbox"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L77">hostClients/whisperService.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L77">hostClients/whisperService.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -317,7 +317,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Email<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"email"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L75">hostClients/whisperService.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L75">hostClients/whisperService.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Inputs<span class="tsd-signature-symbol">:</span> <a href="globals.html#whisperformpassword" class="tsd-signature-type">WhisperFormPassword</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformemail" class="tsd-signature-type">WhisperFormEmail</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformcheckbox" class="tsd-signature-type">WhisperFormCheckbox</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformmarkdown" class="tsd-signature-type">WhisperFormMarkdown</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformnumber" class="tsd-signature-type">WhisperFormNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformradio" class="tsd-signature-type">WhisperFormRadio</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformselect" class="tsd-signature-type">WhisperFormSelect</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtelephonenumber" class="tsd-signature-type">WhisperFormTelephoneNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtext" class="tsd-signature-type">WhisperFormText</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtime" class="tsd-signature-type">WhisperFormTime</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L110">hostClients/whisperService.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L110">hostClients/whisperService.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -337,7 +337,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Markdown<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"markdown"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L82">hostClients/whisperService.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L82">hostClients/whisperService.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -347,7 +347,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"number"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>max<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>min<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L84">hostClients/whisperService.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L84">hostClients/whisperService.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -357,7 +357,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Output<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L136">hostClients/whisperService.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L136">hostClients/whisperService.ts:136</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -367,7 +367,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Password<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"password"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L89">hostClients/whisperService.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L89">hostClients/whisperService.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -377,7 +377,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Radio<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"radio"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L91">hostClients/whisperService.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L91">hostClients/whisperService.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -387,7 +387,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Select<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"select"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L95">hostClients/whisperService.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L95">hostClients/whisperService.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -397,7 +397,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Telephone<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"telephone"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>pattern<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L99">hostClients/whisperService.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L99">hostClients/whisperService.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -407,7 +407,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Text<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"text"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L106">hostClients/whisperService.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L106">hostClients/whisperService.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -417,7 +417,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Time<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"date"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L108">hostClients/whisperService.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L108">hostClients/whisperService.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -430,7 +430,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -447,7 +447,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L147">hostClients/whisperMessageBuilder.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L147">hostClients/whisperMessageBuilder.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L139">hostClients/whisperMessageBuilder.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L139">hostClients/whisperMessageBuilder.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -493,7 +493,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L123">hostClients/whisperMessageBuilder.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L123">hostClients/whisperMessageBuilder.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -516,7 +516,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L28">hostClients/whisperMessageBuilder.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L28">hostClients/whisperMessageBuilder.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L105">hostClients/whisperMessageBuilder.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L105">hostClients/whisperMessageBuilder.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/serve.ts#L9">serve.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/serve.ts#L9">serve.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -593,7 +593,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageBuilder.ts#L20">hostClients/whisperMessageBuilder.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L20">hostClients/whisperMessageBuilder.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -629,7 +629,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageParser.ts#L10">hostClients/whisperMessageParser.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L10">hostClients/whisperMessageParser.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -652,7 +652,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageParser.ts#L51">hostClients/whisperMessageParser.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L51">hostClients/whisperMessageParser.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -680,7 +680,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageParser.ts#L74">hostClients/whisperMessageParser.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L74">hostClients/whisperMessageParser.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -703,7 +703,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageParser.ts#L61">hostClients/whisperMessageParser.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L61">hostClients/whisperMessageParser.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -726,7 +726,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperMessageParser.ts#L41">hostClients/whisperMessageParser.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L41">hostClients/whisperMessageParser.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/globals.html
+++ b/ldk/node/docs/globals.html
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">Form<wbr>Message&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>setLabel<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>setTooltip<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">hostClients/whisperMessageBuilder.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">hostClients/whisperMessageBuilder.ts:11</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -205,7 +205,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">hostClients/whisperMessageBuilder.ts:12</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">hostClients/whisperMessageBuilder.ts:12</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -227,7 +227,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">hostClients/whisperMessageBuilder.ts:13</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">hostClients/whisperMessageBuilder.ts:13</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Listener&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, input<span class="tsd-signature-symbol">?: </span><a href="" class="tsd-signature-type">T</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L8">hostClients/stoppableStream.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/stoppableStream.ts#L8">hostClients/stoppableStream.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Checkbox<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"checkbox"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L77">hostClients/whisperService.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L77">hostClients/whisperService.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -317,7 +317,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Email<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"email"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L75">hostClients/whisperService.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L75">hostClients/whisperService.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Inputs<span class="tsd-signature-symbol">:</span> <a href="globals.html#whisperformpassword" class="tsd-signature-type">WhisperFormPassword</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformemail" class="tsd-signature-type">WhisperFormEmail</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformcheckbox" class="tsd-signature-type">WhisperFormCheckbox</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformmarkdown" class="tsd-signature-type">WhisperFormMarkdown</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformnumber" class="tsd-signature-type">WhisperFormNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformradio" class="tsd-signature-type">WhisperFormRadio</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformselect" class="tsd-signature-type">WhisperFormSelect</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtelephonenumber" class="tsd-signature-type">WhisperFormTelephoneNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtext" class="tsd-signature-type">WhisperFormText</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtime" class="tsd-signature-type">WhisperFormTime</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L110">hostClients/whisperService.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L110">hostClients/whisperService.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -337,7 +337,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Markdown<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"markdown"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L82">hostClients/whisperService.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L82">hostClients/whisperService.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -347,7 +347,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"number"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>max<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>min<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L84">hostClients/whisperService.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L84">hostClients/whisperService.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -357,7 +357,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Output<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L136">hostClients/whisperService.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L136">hostClients/whisperService.ts:136</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -367,7 +367,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Password<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"password"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L89">hostClients/whisperService.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L89">hostClients/whisperService.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -377,7 +377,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Radio<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"radio"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L91">hostClients/whisperService.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L91">hostClients/whisperService.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -387,7 +387,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Select<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"select"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L95">hostClients/whisperService.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L95">hostClients/whisperService.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -397,7 +397,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Telephone<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"telephone"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>pattern<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L99">hostClients/whisperService.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L99">hostClients/whisperService.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -407,7 +407,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Text<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"text"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L106">hostClients/whisperService.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L106">hostClients/whisperService.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -417,7 +417,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Time<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"date"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L108">hostClients/whisperService.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L108">hostClients/whisperService.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -430,7 +430,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -447,7 +447,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L147">hostClients/whisperMessageBuilder.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L147">hostClients/whisperMessageBuilder.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L139">hostClients/whisperMessageBuilder.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L139">hostClients/whisperMessageBuilder.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -493,7 +493,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L123">hostClients/whisperMessageBuilder.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L123">hostClients/whisperMessageBuilder.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -516,7 +516,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L28">hostClients/whisperMessageBuilder.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L28">hostClients/whisperMessageBuilder.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L105">hostClients/whisperMessageBuilder.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L105">hostClients/whisperMessageBuilder.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/serve.ts#L9">serve.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/serve.ts#L9">serve.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -593,7 +593,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L20">hostClients/whisperMessageBuilder.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageBuilder.ts#L20">hostClients/whisperMessageBuilder.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -629,7 +629,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L10">hostClients/whisperMessageParser.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageParser.ts#L10">hostClients/whisperMessageParser.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -652,7 +652,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L51">hostClients/whisperMessageParser.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageParser.ts#L51">hostClients/whisperMessageParser.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -680,7 +680,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L74">hostClients/whisperMessageParser.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageParser.ts#L74">hostClients/whisperMessageParser.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -703,7 +703,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L61">hostClients/whisperMessageParser.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageParser.ts#L61">hostClients/whisperMessageParser.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -726,7 +726,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperMessageParser.ts#L41">hostClients/whisperMessageParser.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperMessageParser.ts#L41">hostClients/whisperMessageParser.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/interfaces/browserselectedtextresponse.html
+++ b/ldk/node/docs/interfaces/browserselectedtextresponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">tab<wbr>Title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L6">hostClients/browserService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L6">hostClients/browserService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L4">hostClients/browserService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L4">hostClients/browserService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L5">hostClients/browserService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L5">hostClients/browserService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/browserselectedtextresponse.html
+++ b/ldk/node/docs/interfaces/browserselectedtextresponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">tab<wbr>Title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L6">hostClients/browserService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L6">hostClients/browserService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L4">hostClients/browserService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L4">hostClients/browserService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L5">hostClients/browserService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L5">hostClients/browserService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/browserservice.html
+++ b/ldk/node/docs/interfaces/browserservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L18">hostClients/browserService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L18">hostClients/browserService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L33">hostClients/browserService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L33">hostClients/browserService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L26">hostClients/browserService.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L26">hostClients/browserService.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L40">hostClients/browserService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/browserService.ts#L40">hostClients/browserService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/browserservice.html
+++ b/ldk/node/docs/interfaces/browserservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L18">hostClients/browserService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L18">hostClients/browserService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L33">hostClients/browserService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L33">hostClients/browserService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L26">hostClients/browserService.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L26">hostClients/browserService.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/browserService.ts#L40">hostClients/browserService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/browserService.ts#L40">hostClients/browserService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/clipboardservice.html
+++ b/ldk/node/docs/interfaces/clipboardservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L10">hostClients/clipboardService.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/clipboardService.ts#L10">hostClients/clipboardService.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L18">hostClients/clipboardService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/clipboardService.ts#L18">hostClients/clipboardService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L25">hostClients/clipboardService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/clipboardService.ts#L25">hostClients/clipboardService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/clipboardservice.html
+++ b/ldk/node/docs/interfaces/clipboardservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/clipboardService.ts#L10">hostClients/clipboardService.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L10">hostClients/clipboardService.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/clipboardService.ts#L18">hostClients/clipboardService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L18">hostClients/clipboardService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/clipboardService.ts#L25">hostClients/clipboardService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/clipboardService.ts#L25">hostClients/clipboardService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/cursorresponse.html
+++ b/ldk/node/docs/interfaces/cursorresponse.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/cursorService.ts#L12">hostClients/cursorService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L12">hostClients/cursorService.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/cursorService.ts#L7">hostClients/cursorService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L7">hostClients/cursorService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/cursorService.ts#L8">hostClients/cursorService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L8">hostClients/cursorService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/cursorresponse.html
+++ b/ldk/node/docs/interfaces/cursorresponse.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L12">hostClients/cursorService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/cursorService.ts#L12">hostClients/cursorService.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L7">hostClients/cursorService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/cursorService.ts#L7">hostClients/cursorService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L8">hostClients/cursorService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/cursorService.ts#L8">hostClients/cursorService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/cursorservice.html
+++ b/ldk/node/docs/interfaces/cursorservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/cursorService.ts#L22">hostClients/cursorService.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L22">hostClients/cursorService.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/cursorService.ts#L30">hostClients/cursorService.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L30">hostClients/cursorService.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/cursorservice.html
+++ b/ldk/node/docs/interfaces/cursorservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L22">hostClients/cursorService.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/cursorService.ts#L22">hostClients/cursorService.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/cursorService.ts#L30">hostClients/cursorService.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/cursorService.ts#L30">hostClients/cursorService.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/fileinfo.html
+++ b/ldk/node/docs/interfaces/fileinfo.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Dir<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L27">hostClients/fileSystemService.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L27">hostClients/fileSystemService.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L19">hostClients/fileSystemService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L19">hostClients/fileSystemService.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L10">hostClients/fileSystemService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L10">hostClients/fileSystemService.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L14">hostClients/fileSystemService.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L14">hostClients/fileSystemService.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L23">hostClients/fileSystemService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L23">hostClients/fileSystemService.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/fileinfo.html
+++ b/ldk/node/docs/interfaces/fileinfo.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Dir<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L27">hostClients/fileSystemService.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L27">hostClients/fileSystemService.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L19">hostClients/fileSystemService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L19">hostClients/fileSystemService.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L10">hostClients/fileSystemService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L10">hostClients/fileSystemService.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L14">hostClients/fileSystemService.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L14">hostClients/fileSystemService.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L23">hostClients/fileSystemService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L23">hostClients/fileSystemService.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">directory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L31">hostClients/fileSystemService.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L31">hostClients/fileSystemService.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">directory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L31">hostClients/fileSystemService.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L31">hostClients/fileSystemService.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L39">hostClients/fileSystemService.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L39">hostClients/fileSystemService.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L39">hostClients/fileSystemService.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L39">hostClients/fileSystemService.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileparams.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L35">hostClients/fileSystemService.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L35">hostClients/fileSystemService.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileparams.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L35">hostClients/fileSystemService.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L35">hostClients/fileSystemService.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L59">hostClients/fileSystemService.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L59">hostClients/fileSystemService.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L59">hostClients/fileSystemService.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L59">hostClients/fileSystemService.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemservice.html
+++ b/ldk/node/docs/interfaces/filesystemservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L76">hostClients/fileSystemService.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L76">hostClients/fileSystemService.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L99">hostClients/fileSystemService.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L99">hostClients/fileSystemService.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L86">hostClients/fileSystemService.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L86">hostClients/fileSystemService.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L109">hostClients/fileSystemService.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L109">hostClients/fileSystemService.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/filesystemservice.html
+++ b/ldk/node/docs/interfaces/filesystemservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L76">hostClients/fileSystemService.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L76">hostClients/fileSystemService.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L99">hostClients/fileSystemService.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L99">hostClients/fileSystemService.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L86">hostClients/fileSystemService.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L86">hostClients/fileSystemService.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L109">hostClients/fileSystemService.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L109">hostClients/fileSystemService.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L55">hostClients/fileSystemService.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L55">hostClients/fileSystemService.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L54">hostClients/fileSystemService.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L54">hostClients/fileSystemService.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L55">hostClients/fileSystemService.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L55">hostClients/fileSystemService.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L54">hostClients/fileSystemService.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L54">hostClients/fileSystemService.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L64">hostClients/fileSystemService.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L64">hostClients/fileSystemService.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L63">hostClients/fileSystemService.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/fileSystemService.ts#L63">hostClients/fileSystemService.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L64">hostClients/fileSystemService.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L64">hostClients/fileSystemService.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/fileSystemService.ts#L63">hostClients/fileSystemService.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/fileSystemService.ts#L63">hostClients/fileSystemService.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hostservices.html
+++ b/ldk/node/docs/interfaces/hostservices.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<span class="tsd-signature-symbol">:</span> <a href="browserservice.html" class="tsd-signature-type">BrowserService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L25">hostServices.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L25">hostServices.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">clipboard<span class="tsd-signature-symbol">:</span> <a href="clipboardservice.html" class="tsd-signature-type">ClipboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L19">hostServices.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L19">hostServices.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">cursor<span class="tsd-signature-symbol">:</span> <a href="cursorservice.html" class="tsd-signature-type">CursorService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L20">hostServices.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L20">hostServices.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<wbr>System<span class="tsd-signature-symbol">:</span> <a href="filesystemservice.html" class="tsd-signature-type">FileSystemService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L22">hostServices.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L22">hostServices.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">hover<span class="tsd-signature-symbol">:</span> <a href="hoverservice.html" class="tsd-signature-type">HoverService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L21">hostServices.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L21">hostServices.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">keyboard<span class="tsd-signature-symbol">:</span> <a href="keyboardservice.html" class="tsd-signature-type">KeyboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L18">hostServices.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L18">hostServices.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processservice.html" class="tsd-signature-type">ProcessService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L23">hostServices.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L23">hostServices.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">storage<span class="tsd-signature-symbol">:</span> <a href="storageservice.html" class="tsd-signature-type">StorageService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L17">hostServices.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L17">hostServices.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">whisper<span class="tsd-signature-symbol">:</span> <a href="whisperservice.html" class="tsd-signature-type">WhisperService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L16">hostServices.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L16">hostServices.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <a href="windowservice.html" class="tsd-signature-type">WindowService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L24">hostServices.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostServices.ts#L24">hostServices.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hostservices.html
+++ b/ldk/node/docs/interfaces/hostservices.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<span class="tsd-signature-symbol">:</span> <a href="browserservice.html" class="tsd-signature-type">BrowserService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L25">hostServices.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L25">hostServices.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">clipboard<span class="tsd-signature-symbol">:</span> <a href="clipboardservice.html" class="tsd-signature-type">ClipboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L19">hostServices.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L19">hostServices.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">cursor<span class="tsd-signature-symbol">:</span> <a href="cursorservice.html" class="tsd-signature-type">CursorService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L20">hostServices.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L20">hostServices.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<wbr>System<span class="tsd-signature-symbol">:</span> <a href="filesystemservice.html" class="tsd-signature-type">FileSystemService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L22">hostServices.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L22">hostServices.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">hover<span class="tsd-signature-symbol">:</span> <a href="hoverservice.html" class="tsd-signature-type">HoverService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L21">hostServices.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L21">hostServices.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">keyboard<span class="tsd-signature-symbol">:</span> <a href="keyboardservice.html" class="tsd-signature-type">KeyboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L18">hostServices.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L18">hostServices.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processservice.html" class="tsd-signature-type">ProcessService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L23">hostServices.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L23">hostServices.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">storage<span class="tsd-signature-symbol">:</span> <a href="storageservice.html" class="tsd-signature-type">StorageService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L17">hostServices.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L17">hostServices.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">whisper<span class="tsd-signature-symbol">:</span> <a href="whisperservice.html" class="tsd-signature-type">WhisperService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L16">hostServices.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L16">hostServices.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <a href="windowservice.html" class="tsd-signature-type">WindowService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostServices.ts#L24">hostServices.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostServices.ts#L24">hostServices.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyevent.html
+++ b/ldk/node/docs/interfaces/hotkeyevent.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"down"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"up"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L21">hostClients/keyboardService.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L21">hostClients/keyboardService.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyevent.html
+++ b/ldk/node/docs/interfaces/hotkeyevent.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"down"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"up"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L21">hostClients/keyboardService.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L21">hostClients/keyboardService.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyrequest.html
+++ b/ldk/node/docs/interfaces/hotkeyrequest.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L16">hostClients/keyboardService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L16">hostClients/keyboardService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">modifiers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="keyboardmodifiers.html" class="tsd-signature-type">KeyboardModifiers</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L17">hostClients/keyboardService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L17">hostClients/keyboardService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyrequest.html
+++ b/ldk/node/docs/interfaces/hotkeyrequest.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L16">hostClients/keyboardService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L16">hostClients/keyboardService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">modifiers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="keyboardmodifiers.html" class="tsd-signature-type">KeyboardModifiers</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L17">hostClients/keyboardService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L17">hostClients/keyboardService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverreadrequest.html
+++ b/ldk/node/docs/interfaces/hoverreadrequest.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/hoverService.ts#L11">hostClients/hoverService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L11">hostClients/hoverService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/hoverService.ts#L12">hostClients/hoverService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L12">hostClients/hoverService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverreadrequest.html
+++ b/ldk/node/docs/interfaces/hoverreadrequest.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L11">hostClients/hoverService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/hoverService.ts#L11">hostClients/hoverService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L12">hostClients/hoverService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/hoverService.ts#L12">hostClients/hoverService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverresponse.html
+++ b/ldk/node/docs/interfaces/hoverresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L4">hostClients/hoverService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/hoverService.ts#L4">hostClients/hoverService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverresponse.html
+++ b/ldk/node/docs/interfaces/hoverresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/hoverService.ts#L4">hostClients/hoverService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L4">hostClients/hoverService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverservice.html
+++ b/ldk/node/docs/interfaces/hoverservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/hoverService.ts#L25">hostClients/hoverService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L25">hostClients/hoverService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/hoverService.ts#L34">hostClients/hoverService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L34">hostClients/hoverService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/hoverservice.html
+++ b/ldk/node/docs/interfaces/hoverservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L25">hostClients/hoverService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/hoverService.ts#L25">hostClients/hoverService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/hoverService.ts#L34">hostClients/hoverService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/hoverService.ts#L34">hostClients/hoverService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/keyboardmodifiers.html
+++ b/ldk/node/docs/interfaces/keyboardmodifiers.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">altL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L4">hostClients/keyboardService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L4">hostClients/keyboardService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">altR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L5">hostClients/keyboardService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L5">hostClients/keyboardService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L6">hostClients/keyboardService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L6">hostClients/keyboardService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L7">hostClients/keyboardService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L7">hostClients/keyboardService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L8">hostClients/keyboardService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L8">hostClients/keyboardService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L9">hostClients/keyboardService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L9">hostClients/keyboardService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L10">hostClients/keyboardService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L10">hostClients/keyboardService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L11">hostClients/keyboardService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L11">hostClients/keyboardService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/keyboardmodifiers.html
+++ b/ldk/node/docs/interfaces/keyboardmodifiers.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">altL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L4">hostClients/keyboardService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L4">hostClients/keyboardService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">altR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L5">hostClients/keyboardService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L5">hostClients/keyboardService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L6">hostClients/keyboardService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L6">hostClients/keyboardService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L7">hostClients/keyboardService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L7">hostClients/keyboardService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L8">hostClients/keyboardService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L8">hostClients/keyboardService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L9">hostClients/keyboardService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L9">hostClients/keyboardService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L10">hostClients/keyboardService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L10">hostClients/keyboardService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L11">hostClients/keyboardService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L11">hostClients/keyboardService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/keyboardservice.html
+++ b/ldk/node/docs/interfaces/keyboardservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L49">hostClients/keyboardService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L49">hostClients/keyboardService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L68">hostClients/keyboardService.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L68">hostClients/keyboardService.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L56">hostClients/keyboardService.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L56">hostClients/keyboardService.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L42">hostClients/keyboardService.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L42">hostClients/keyboardService.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/keyboardservice.html
+++ b/ldk/node/docs/interfaces/keyboardservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L49">hostClients/keyboardService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L49">hostClients/keyboardService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L68">hostClients/keyboardService.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L68">hostClients/keyboardService.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L56">hostClients/keyboardService.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L56">hostClients/keyboardService.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L42">hostClients/keyboardService.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L42">hostClients/keyboardService.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/loop.html
+++ b/ldk/node/docs/interfaces/loop.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/loop.ts#L34">loop.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/loop.ts#L34">loop.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/loop.ts#L39">loop.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/loop.ts#L39">loop.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/loop.html
+++ b/ldk/node/docs/interfaces/loop.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/loop.ts#L34">loop.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/loop.ts#L34">loop.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/loop.ts#L39">loop.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/loop.ts#L39">loop.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/processinforesponse.html
+++ b/ldk/node/docs/interfaces/processinforesponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">arguments<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L13">hostClients/processService.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L13">hostClients/processService.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">command<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L12">hostClients/processService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L12">hostClients/processService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L11">hostClients/processService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L11">hostClients/processService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processinforesponse.html
+++ b/ldk/node/docs/interfaces/processinforesponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">arguments<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L13">hostClients/processService.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L13">hostClients/processService.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">command<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L12">hostClients/processService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L12">hostClients/processService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L11">hostClients/processService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L11">hostClients/processService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processlistresponse.html
+++ b/ldk/node/docs/interfaces/processlistresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">processes<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L22">hostClients/processService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L22">hostClients/processService.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processlistresponse.html
+++ b/ldk/node/docs/interfaces/processlistresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">processes<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L22">hostClients/processService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L22">hostClients/processService.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processservice.html
+++ b/ldk/node/docs/interfaces/processservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L34">hostClients/processService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L34">hostClients/processService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L41">hostClients/processService.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L41">hostClients/processService.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/processservice.html
+++ b/ldk/node/docs/interfaces/processservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L34">hostClients/processService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L34">hostClients/processService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L41">hostClients/processService.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L41">hostClients/processService.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/processstreamresponse.html
+++ b/ldk/node/docs/interfaces/processstreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/processstreamaction.html" class="tsd-signature-type">ProcessStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L18">hostClients/processService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L18">hostClients/processService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/processService.ts#L17">hostClients/processService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L17">hostClients/processService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processstreamresponse.html
+++ b/ldk/node/docs/interfaces/processstreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/processstreamaction.html" class="tsd-signature-type">ProcessStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L18">hostClients/processService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L18">hostClients/processService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/processService.ts#L17">hostClients/processService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/processService.ts#L17">hostClients/processService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/scancodeevent.html
+++ b/ldk/node/docs/interfaces/scancodeevent.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"up"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"down"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L30">hostClients/keyboardService.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L30">hostClients/keyboardService.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">scan<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L29">hostClients/keyboardService.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L29">hostClients/keyboardService.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/scancodeevent.html
+++ b/ldk/node/docs/interfaces/scancodeevent.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"up"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"down"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L30">hostClients/keyboardService.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L30">hostClients/keyboardService.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">scan<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L29">hostClients/keyboardService.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L29">hostClients/keyboardService.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/stoppablestream.html
+++ b/ldk/node/docs/interfaces/stoppablestream.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L16">hostClients/stoppableStream.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/stoppableStream.ts#L16">hostClients/stoppableStream.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L14">hostClients/stoppableStream.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/stoppableStream.ts#L14">hostClients/stoppableStream.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/ldk/node/docs/interfaces/stoppablestream.html
+++ b/ldk/node/docs/interfaces/stoppablestream.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/stoppableStream.ts#L16">hostClients/stoppableStream.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L16">hostClients/stoppableStream.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/stoppableStream.ts#L14">hostClients/stoppableStream.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/stoppableStream.ts#L14">hostClients/stoppableStream.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/ldk/node/docs/interfaces/storageservice.html
+++ b/ldk/node/docs/interfaces/storageservice.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L9">hostClients/storageService.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L9">hostClients/storageService.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L14">hostClients/storageService.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L14">hostClients/storageService.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L20">hostClients/storageService.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L20">hostClients/storageService.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L25">hostClients/storageService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L25">hostClients/storageService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L33">hostClients/storageService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L33">hostClients/storageService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L40">hostClients/storageService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L40">hostClients/storageService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L49">hostClients/storageService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/storageService.ts#L49">hostClients/storageService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/storageservice.html
+++ b/ldk/node/docs/interfaces/storageservice.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L9">hostClients/storageService.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L9">hostClients/storageService.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L14">hostClients/storageService.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L14">hostClients/storageService.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L20">hostClients/storageService.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L20">hostClients/storageService.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L25">hostClients/storageService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L25">hostClients/storageService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L33">hostClients/storageService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L33">hostClients/storageService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L40">hostClients/storageService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L40">hostClients/storageService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/storageService.ts#L49">hostClients/storageService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/storageService.ts#L49">hostClients/storageService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/textstream.html
+++ b/ldk/node/docs/interfaces/textstream.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L25">hostClients/keyboardService.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/keyboardService.ts#L25">hostClients/keyboardService.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/textstream.html
+++ b/ldk/node/docs/interfaces/textstream.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/keyboardService.ts#L25">hostClients/keyboardService.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/keyboardService.ts#L25">hostClients/keyboardService.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisper.html
+++ b/ldk/node/docs/interfaces/whisper.html
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisper.html
+++ b/ldk/node/docs/interfaces/whisper.html
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperconfirmconfig.html
+++ b/ldk/node/docs/interfaces/whisperconfirmconfig.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">reject<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L123">hostClients/whisperService.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L123">hostClients/whisperService.ts:123</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">resolve<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L125">hostClients/whisperService.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L125">hostClients/whisperService.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperconfirmconfig.html
+++ b/ldk/node/docs/interfaces/whisperconfirmconfig.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">reject<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L123">hostClients/whisperService.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L123">hostClients/whisperService.ts:123</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">resolve<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L125">hostClients/whisperService.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L125">hostClients/whisperService.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperformconfig.html
+++ b/ldk/node/docs/interfaces/whisperformconfig.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L131">hostClients/whisperService.ts:131</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L131">hostClients/whisperService.ts:131</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">inputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L133">hostClients/whisperService.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L133">hostClients/whisperService.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">submit<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L129">hostClients/whisperService.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L129">hostClients/whisperService.ts:129</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformconfig.html
+++ b/ldk/node/docs/interfaces/whisperformconfig.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L131">hostClients/whisperService.ts:131</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L131">hostClients/whisperService.ts:131</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L53">hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">inputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L133">hostClients/whisperService.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L133">hostClients/whisperService.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L57">hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L49">hostClients/whisperService.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L61">hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">submit<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L129">hostClients/whisperService.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L129">hostClients/whisperService.ts:129</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminput.html
+++ b/ldk/node/docs/interfaces/whisperforminput.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">tooltip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminput.html
+++ b/ldk/node/docs/interfaces/whisperforminput.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">tooltip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminputwithvalue.html
+++ b/ldk/node/docs/interfaces/whisperforminputwithvalue.html
@@ -114,7 +114,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#tooltip">tooltip</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L72">hostClients/whisperService.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L72">hostClients/whisperService.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminputwithvalue.html
+++ b/ldk/node/docs/interfaces/whisperforminputwithvalue.html
@@ -114,7 +114,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L65">hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#tooltip">tooltip</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L66">hostClients/whisperService.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L67">hostClients/whisperService.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L72">hostClients/whisperService.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L72">hostClients/whisperService.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformsubmitevent.html
+++ b/ldk/node/docs/interfaces/whisperformsubmitevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">outputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L146">hostClients/whisperService.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L146">hostClients/whisperService.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">submitted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L145">hostClients/whisperService.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L145">hostClients/whisperService.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"submit"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L147">hostClients/whisperService.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L147">hostClients/whisperService.ts:147</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformsubmitevent.html
+++ b/ldk/node/docs/interfaces/whisperformsubmitevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">outputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L146">hostClients/whisperService.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L146">hostClients/whisperService.ts:146</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">submitted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L145">hostClients/whisperService.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L145">hostClients/whisperService.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"submit"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L147">hostClients/whisperService.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L147">hostClients/whisperService.ts:147</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformupdateevent.html
+++ b/ldk/node/docs/interfaces/whisperformupdateevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L139">hostClients/whisperService.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L139">hostClients/whisperService.ts:139</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L141">hostClients/whisperService.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L141">hostClients/whisperService.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../globals.html#whisperformoutputtypes" class="tsd-signature-type">WhisperFormOutputTypes</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L140">hostClients/whisperService.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L140">hostClients/whisperService.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformupdateevent.html
+++ b/ldk/node/docs/interfaces/whisperformupdateevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L139">hostClients/whisperService.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L139">hostClients/whisperService.ts:139</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L141">hostClients/whisperService.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L141">hostClients/whisperService.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../globals.html#whisperformoutputtypes" class="tsd-signature-type">WhisperFormOutputTypes</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L140">hostClients/whisperService.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L140">hostClients/whisperService.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperservice.html
+++ b/ldk/node/docs/interfaces/whisperservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L159">hostClients/whisperService.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L159">hostClients/whisperService.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L161">hostClients/whisperService.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L161">hostClients/whisperService.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L157">hostClients/whisperService.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L157">hostClients/whisperService.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperservice.html
+++ b/ldk/node/docs/interfaces/whisperservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L159">hostClients/whisperService.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L159">hostClients/whisperService.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L161">hostClients/whisperService.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L161">hostClients/whisperService.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L157">hostClients/whisperService.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L157">hostClients/whisperService.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperstyle.html
+++ b/ldk/node/docs/interfaces/whisperstyle.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L18">hostClients/whisperService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L18">hostClients/whisperService.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L22">hostClients/whisperService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L22">hostClients/whisperService.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/whisperService.ts#L26">hostClients/whisperService.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L26">hostClients/whisperService.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperstyle.html
+++ b/ldk/node/docs/interfaces/whisperstyle.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L18">hostClients/whisperService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L18">hostClients/whisperService.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L22">hostClients/whisperService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L22">hostClients/whisperService.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/whisperService.ts#L26">hostClients/whisperService.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/whisperService.ts#L26">hostClients/whisperService.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/windowinforesponse.html
+++ b/ldk/node/docs/interfaces/windowinforesponse.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L10">hostClients/windowService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L10">hostClients/windowService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L5">hostClients/windowService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L5">hostClients/windowService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L6">hostClients/windowService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L6">hostClients/windowService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L4">hostClients/windowService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L4">hostClients/windowService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L9">hostClients/windowService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L9">hostClients/windowService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L7">hostClients/windowService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L7">hostClients/windowService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L8">hostClients/windowService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L8">hostClients/windowService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowinforesponse.html
+++ b/ldk/node/docs/interfaces/windowinforesponse.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L10">hostClients/windowService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L10">hostClients/windowService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L5">hostClients/windowService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L5">hostClients/windowService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L6">hostClients/windowService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L6">hostClients/windowService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L4">hostClients/windowService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L4">hostClients/windowService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L9">hostClients/windowService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L9">hostClients/windowService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L7">hostClients/windowService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L7">hostClients/windowService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L8">hostClients/windowService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L8">hostClients/windowService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowinfostreamresponse.html
+++ b/ldk/node/docs/interfaces/windowinfostreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/windowstreamaction.html" class="tsd-signature-type">WindowStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L24">hostClients/windowService.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L24">hostClients/windowService.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <a href="windowinforesponse.html" class="tsd-signature-type">WindowInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L23">hostClients/windowService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L23">hostClients/windowService.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowinfostreamresponse.html
+++ b/ldk/node/docs/interfaces/windowinfostreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/windowstreamaction.html" class="tsd-signature-type">WindowStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L24">hostClients/windowService.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L24">hostClients/windowService.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <a href="windowinforesponse.html" class="tsd-signature-type">WindowInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L23">hostClients/windowService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L23">hostClients/windowService.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowservice.html
+++ b/ldk/node/docs/interfaces/windowservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L36">hostClients/windowService.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L36">hostClients/windowService.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L43">hostClients/windowService.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L43">hostClients/windowService.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L50">hostClients/windowService.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L50">hostClients/windowService.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/66b5241/ldk/node/src/hostClients/windowService.ts#L59">hostClients/windowService.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L59">hostClients/windowService.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/windowservice.html
+++ b/ldk/node/docs/interfaces/windowservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L36">hostClients/windowService.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L36">hostClients/windowService.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L43">hostClients/windowService.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L43">hostClients/windowService.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L50">hostClients/windowService.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L50">hostClients/windowService.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/9e5fd8b/ldk/node/src/hostClients/windowService.ts#L59">hostClients/windowService.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/8f80d0b/ldk/node/src/hostClients/windowService.ts#L59">hostClients/windowService.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">


### PR DESCRIPTION
This PR updates the examples' `Makefiles` with the new App Support folder location, and adds the Windows linter back to the Go Linter.