### PR TITLE
SIDE-1004 - Add template docs back

### DIFF
--- a/ldk/node/dist/hostClients/stoppables.d.ts
+++ b/ldk/node/dist/hostClients/stoppables.d.ts
@@ -1,10 +1,14 @@
 /**
  * The StreamListener type is a function provided to start a stream. It accepts two parameters and returns nothing.
  *
+ * @template T - The type of the messages sent.
  * @param error - Null, unless an error is present.
  * @param input - The event that's being generated.
  */
 export declare type StreamListener<T> = (error: string | null, input?: T) => void;
+/**
+ * @template T - The type of the messages sent.
+ */
 export interface StoppableStream<T> {
     stop(): void;
     setListener(callback: StreamListener<T>): void;
@@ -12,6 +16,8 @@ export interface StoppableStream<T> {
 /**
  * The StoppableMessage interface provides access to a promise that resolves when the message completes, and
  * to the ability to stop the message.
+ *
+ * @template T - The type of the messages sent.
  */
 export interface StoppableMessage<T> {
     stop(): void;

--- a/ldk/node/docs/classes/logger.html
+++ b/ldk/node/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L27">src/logging.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L27">src/logging.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L114">src/logging.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L114">src/logging.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L177">src/logging.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L177">src/logging.ts:177</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L135">src/logging.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L135">src/logging.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L93">src/logging.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L93">src/logging.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L156">src/logging.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L156">src/logging.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/logging.ts#L71">src/logging.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/logging.ts#L71">src/logging.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/classes/networkclient.html
+++ b/ldk/node/docs/classes/networkclient.html
@@ -125,7 +125,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseClient._session</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L40">src/hostClients/baseClient.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L40">src/hostClients/baseClient.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.client</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L142">src/hostClients/baseClient.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L142">src/hostClients/baseClient.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">NetworkGRPCClient</span></h4>
@@ -153,7 +153,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.client</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L149">src/hostClients/baseClient.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L149">src/hostClients/baseClient.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.session</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L153">src/hostClients/baseClient.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L153">src/hostClients/baseClient.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Session.AsObject</span></h4>
@@ -187,7 +187,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.session</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L160">src/hostClients/baseClient.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L160">src/hostClients/baseClient.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -214,7 +214,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.buildQuery</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L98">src/hostClients/baseClient.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L98">src/hostClients/baseClient.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -343,7 +343,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.buildStoppableMessage</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L119">src/hostClients/baseClient.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L119">src/hostClients/baseClient.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.connect</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L57">src/hostClients/baseClient.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L57">src/hostClients/baseClient.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -505,7 +505,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.createSessionMessage</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L135">src/hostClients/baseClient.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L135">src/hostClients/baseClient.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Session</span></h4>
@@ -523,7 +523,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides BaseClient.generateClient</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkClient.ts#L9">src/hostClients/networkClient.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkClient.ts#L9">src/hostClients/networkClient.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">GRPCClientConstructor</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">NetworkGRPCClient</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -541,7 +541,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/networkservice.html">NetworkService</a>.<a href="../interfaces/networkservice.html#httprequest">httpRequest</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkClient.ts#L13">src/hostClients/networkClient.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkClient.ts#L13">src/hostClients/networkClient.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/classes/plugin.html
+++ b/ldk/node/docs/classes/plugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/plugin.ts#L17">src/plugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/plugin.ts#L17">src/plugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/plugin.ts#L38">src/plugin.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/plugin.ts#L38">src/plugin.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/classes/transformingmessage.html
+++ b/ldk/node/docs/classes/transformingmessage.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/transformingMessage.ts#L15">src/hostClients/transformingMessage.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/transformingMessage.ts#L15">src/hostClients/transformingMessage.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/transformingMessage.ts#L41">src/hostClients/transformingMessage.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/transformingMessage.ts#L41">src/hostClients/transformingMessage.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/transformingMessage.ts#L33">src/hostClients/transformingMessage.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/transformingMessage.ts#L33">src/hostClients/transformingMessage.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -218,7 +218,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/stoppablemessage.html">StoppableMessage</a>.<a href="../interfaces/stoppablemessage.html#promise">promise</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/transformingMessage.ts#L25">src/hostClients/transformingMessage.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/transformingMessage.ts#L25">src/hostClients/transformingMessage.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TOutput</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/stoppablemessage.html">StoppableMessage</a>.<a href="../interfaces/stoppablemessage.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/transformingMessage.ts#L29">src/hostClients/transformingMessage.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/transformingMessage.ts#L29">src/hostClients/transformingMessage.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/ldk/node/docs/classes/uiclient.html
+++ b/ldk/node/docs/classes/uiclient.html
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseClient._session</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L40">src/hostClients/baseClient.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L40">src/hostClients/baseClient.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.client</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L142">src/hostClients/baseClient.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L142">src/hostClients/baseClient.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">UIGRPCClient</span></h4>
@@ -154,7 +154,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.client</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L149">src/hostClients/baseClient.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L149">src/hostClients/baseClient.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -179,7 +179,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.session</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L153">src/hostClients/baseClient.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L153">src/hostClients/baseClient.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Session.AsObject</span></h4>
@@ -188,7 +188,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.session</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L160">src/hostClients/baseClient.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L160">src/hostClients/baseClient.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -215,7 +215,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.buildQuery</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L98">src/hostClients/baseClient.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L98">src/hostClients/baseClient.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.buildStoppableMessage</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L119">src/hostClients/baseClient.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L119">src/hostClients/baseClient.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.connect</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L57">src/hostClients/baseClient.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L57">src/hostClients/baseClient.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -506,7 +506,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from BaseClient.createSessionMessage</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/baseClient.ts#L135">src/hostClients/baseClient.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/baseClient.ts#L135">src/hostClients/baseClient.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Session</span></h4>
@@ -524,7 +524,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides BaseClient.generateClient</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/uiClient.ts#L9">src/hostClients/uiClient.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/uiClient.ts#L9">src/hostClients/uiClient.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">GRPCClientConstructor</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UIGRPCClient</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -542,7 +542,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/uiservice.html">UIService</a>.<a href="../interfaces/uiservice.html#streamglobalsearch">streamGlobalSearch</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/uiClient.ts#L27">src/hostClients/uiClient.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/uiClient.ts#L27">src/hostClients/uiClient.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/uiservice.html">UIService</a>.<a href="../interfaces/uiservice.html#streamsearchbar">streamSearchbar</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/uiClient.ts#L13">src/hostClients/uiClient.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/uiClient.ts#L13">src/hostClients/uiClient.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/enums/access.html
+++ b/ldk/node/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/access.ts#L3">src/access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/access.ts#L3">src/access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/access.ts#L4">src/access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/access.ts#L4">src/access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/access.ts#L5">src/access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/access.ts#L5">src/access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/access.ts#L6">src/access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/access.ts#L6">src/access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/category.html
+++ b/ldk/node/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L3">src/categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L3">src/categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L4">src/categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L4">src/categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L5">src/categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L5">src/categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L6">src/categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L6">src/categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L7">src/categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L7">src/categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/filesystemstreamaction.html
+++ b/ldk/node/docs/enums/filesystemstreamaction.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Chmod<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;chmod&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L50">src/hostClients/fileSystemService.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L50">src/hostClients/fileSystemService.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;create&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L46">src/hostClients/fileSystemService.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L46">src/hostClients/fileSystemService.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;remove&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L48">src/hostClients/fileSystemService.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L48">src/hostClients/fileSystemService.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rename<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;rename&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L49">src/hostClients/fileSystemService.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L49">src/hostClients/fileSystemService.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L45">src/hostClients/fileSystemService.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L45">src/hostClients/fileSystemService.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">Write<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;write&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L47">src/hostClients/fileSystemService.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L47">src/hostClients/fileSystemService.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/operatingsystem.html
+++ b/ldk/node/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/operatingSystem.ts#L3">src/operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/operatingSystem.ts#L3">src/operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/operatingSystem.ts#L4">src/operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/operatingSystem.ts#L4">src/operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/operatingSystem.ts#L5">src/operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/operatingSystem.ts#L5">src/operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/operatingSystem.ts#L6">src/operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/operatingSystem.ts#L6">src/operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/operatingSystem.ts#L7">src/operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/operatingSystem.ts#L7">src/operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/processstreamaction.html
+++ b/ldk/node/docs/enums/processstreamaction.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;started&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L6">src/hostClients/processService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L6">src/hostClients/processService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;stopped&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L7">src/hostClients/processService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L7">src/hostClients/processService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L5">src/hostClients/processService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L5">src/hostClients/processService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/enums/windowstreamaction.html
+++ b/ldk/node/docs/enums/windowstreamaction.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Closed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;closed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L19">src/hostClients/windowService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L19">src/hostClients/windowService.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Focused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;focused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L16">src/hostClients/windowService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L16">src/hostClients/windowService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Opened<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;opened&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L18">src/hostClients/windowService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L18">src/hostClients/windowService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unfocused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unfocused&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L17">src/hostClients/windowService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L17">src/hostClients/windowService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L15">src/hostClients/windowService.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L15">src/hostClients/windowService.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/globals.html
+++ b/ldk/node/docs/globals.html
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">Form<wbr>Message&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>setLabel<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>setOrder<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>setTooltip<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">src/hostClients/whisperMessageBuilder.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L11">src/hostClients/whisperMessageBuilder.ts:11</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -214,7 +214,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">src/hostClients/whisperMessageBuilder.ts:12</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L12">src/hostClients/whisperMessageBuilder.ts:12</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -236,7 +236,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L14">src/hostClients/whisperMessageBuilder.ts:14</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L14">src/hostClients/whisperMessageBuilder.ts:14</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">src/hostClients/whisperMessageBuilder.ts:13</a></li>
+												<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L13">src/hostClients/whisperMessageBuilder.ts:13</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Listener&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, input<span class="tsd-signature-symbol">?: </span><a href="" class="tsd-signature-type">T</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/stoppables.ts#L7">src/hostClients/stoppables.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/stoppables.ts#L8">src/hostClients/stoppables.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -300,6 +300,11 @@
 					<ul class="tsd-type-parameters">
 						<li>
 							<h4>T</h4>
+							<div class="tsd-comment tsd-typography">
+								<div class="lead">
+									<p>The type of the messages sent.</p>
+								</div>
+							</div>
 						</li>
 					</ul>
 					<div class="tsd-type-declaration">
@@ -333,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Checkbox<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"checkbox"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L87">src/hostClients/whisperService.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L87">src/hostClients/whisperService.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -343,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Email<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"email"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L85">src/hostClients/whisperService.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L85">src/hostClients/whisperService.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -353,7 +358,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Inputs<span class="tsd-signature-symbol">:</span> <a href="globals.html#whisperformpassword" class="tsd-signature-type">WhisperFormPassword</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformemail" class="tsd-signature-type">WhisperFormEmail</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformcheckbox" class="tsd-signature-type">WhisperFormCheckbox</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformmarkdown" class="tsd-signature-type">WhisperFormMarkdown</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformnumber" class="tsd-signature-type">WhisperFormNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformradio" class="tsd-signature-type">WhisperFormRadio</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformselect" class="tsd-signature-type">WhisperFormSelect</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtelephonenumber" class="tsd-signature-type">WhisperFormTelephoneNumber</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtext" class="tsd-signature-type">WhisperFormText</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#whisperformtime" class="tsd-signature-type">WhisperFormTime</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L120">src/hostClients/whisperService.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L120">src/hostClients/whisperService.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -363,7 +368,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Markdown<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"markdown"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L92">src/hostClients/whisperService.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L92">src/hostClients/whisperService.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -373,7 +378,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"number"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>max<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>min<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L94">src/hostClients/whisperService.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L94">src/hostClients/whisperService.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -383,7 +388,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Output<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L146">src/hostClients/whisperService.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L146">src/hostClients/whisperService.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -393,7 +398,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Password<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"password"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L99">src/hostClients/whisperService.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L99">src/hostClients/whisperService.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -403,7 +408,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Radio<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"radio"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L101">src/hostClients/whisperService.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L101">src/hostClients/whisperService.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -413,7 +418,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Select<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminput.html" class="tsd-signature-type">WhisperFormInput</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"select"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L105">src/hostClients/whisperService.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L105">src/hostClients/whisperService.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -423,7 +428,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Telephone<wbr>Number<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"telephone"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>pattern<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L109">src/hostClients/whisperService.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L109">src/hostClients/whisperService.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -433,7 +438,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Text<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"text"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L116">src/hostClients/whisperService.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L116">src/hostClients/whisperService.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -443,7 +448,7 @@
 					<div class="tsd-signature tsd-kind-icon">Whisper<wbr>Form<wbr>Time<span class="tsd-signature-symbol">:</span> <a href="interfaces/whisperforminputwithvalue.html" class="tsd-signature-type">WhisperFormInputWithValue</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"date"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L118">src/hostClients/whisperService.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L118">src/hostClients/whisperService.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -456,7 +461,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/categories.ts#L10">src/categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/categories.ts#L10">src/categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -466,7 +471,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="classes/logger.html" class="tsd-signature-type">Logger</a><span class="tsd-signature-symbol"> = new Logger(&#x27;loop-core&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/plugin.ts#L7">src/plugin.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/plugin.ts#L7">src/plugin.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -483,7 +488,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L152">src/hostClients/whisperMessageBuilder.ts:152</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L152">src/hostClients/whisperMessageBuilder.ts:152</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -506,7 +511,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L144">src/hostClients/whisperMessageBuilder.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L144">src/hostClients/whisperMessageBuilder.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -529,7 +534,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L128">src/hostClients/whisperMessageBuilder.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L128">src/hostClients/whisperMessageBuilder.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -552,7 +557,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L33">src/hostClients/whisperMessageBuilder.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L33">src/hostClients/whisperMessageBuilder.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -575,7 +580,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L110">src/hostClients/whisperMessageBuilder.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L110">src/hostClients/whisperMessageBuilder.ts:110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -598,7 +603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/serve.ts#L9">src/serve.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/serve.ts#L9">src/serve.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -629,7 +634,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageBuilder.ts#L21">src/hostClients/whisperMessageBuilder.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageBuilder.ts#L21">src/hostClients/whisperMessageBuilder.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -669,7 +674,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageParser.ts#L11">src/hostClients/whisperMessageParser.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageParser.ts#L11">src/hostClients/whisperMessageParser.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -692,7 +697,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageParser.ts#L52">src/hostClients/whisperMessageParser.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageParser.ts#L52">src/hostClients/whisperMessageParser.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -720,7 +725,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageParser.ts#L75">src/hostClients/whisperMessageParser.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageParser.ts#L75">src/hostClients/whisperMessageParser.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -743,7 +748,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageParser.ts#L62">src/hostClients/whisperMessageParser.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageParser.ts#L62">src/hostClients/whisperMessageParser.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -766,7 +771,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperMessageParser.ts#L42">src/hostClients/whisperMessageParser.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperMessageParser.ts#L42">src/hostClients/whisperMessageParser.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/interfaces/browserselectedtextresponse.html
+++ b/ldk/node/docs/interfaces/browserselectedtextresponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">tab<wbr>Title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L6">src/hostClients/browserService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L6">src/hostClients/browserService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L4">src/hostClients/browserService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L4">src/hostClients/browserService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L5">src/hostClients/browserService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L5">src/hostClients/browserService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/browserservice.html
+++ b/ldk/node/docs/interfaces/browserservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L18">src/hostClients/browserService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L18">src/hostClients/browserService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L33">src/hostClients/browserService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L33">src/hostClients/browserService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L26">src/hostClients/browserService.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L26">src/hostClients/browserService.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/browserService.ts#L40">src/hostClients/browserService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/browserService.ts#L40">src/hostClients/browserService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/clipboardservice.html
+++ b/ldk/node/docs/interfaces/clipboardservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/clipboardService.ts#L10">src/hostClients/clipboardService.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/clipboardService.ts#L10">src/hostClients/clipboardService.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/clipboardService.ts#L18">src/hostClients/clipboardService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/clipboardService.ts#L18">src/hostClients/clipboardService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/clipboardService.ts#L25">src/hostClients/clipboardService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/clipboardService.ts#L25">src/hostClients/clipboardService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/cursorresponse.html
+++ b/ldk/node/docs/interfaces/cursorresponse.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/cursorService.ts#L12">src/hostClients/cursorService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/cursorService.ts#L12">src/hostClients/cursorService.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/cursorService.ts#L7">src/hostClients/cursorService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/cursorService.ts#L7">src/hostClients/cursorService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/cursorService.ts#L8">src/hostClients/cursorService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/cursorService.ts#L8">src/hostClients/cursorService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/cursorservice.html
+++ b/ldk/node/docs/interfaces/cursorservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/cursorService.ts#L22">src/hostClients/cursorService.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/cursorService.ts#L22">src/hostClients/cursorService.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/cursorService.ts#L30">src/hostClients/cursorService.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/cursorService.ts#L30">src/hostClients/cursorService.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/fileinfo.html
+++ b/ldk/node/docs/interfaces/fileinfo.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Dir<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L27">src/hostClients/fileSystemService.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L27">src/hostClients/fileSystemService.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L19">src/hostClients/fileSystemService.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L19">src/hostClients/fileSystemService.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L10">src/hostClients/fileSystemService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L10">src/hostClients/fileSystemService.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L14">src/hostClients/fileSystemService.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L14">src/hostClients/fileSystemService.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L23">src/hostClients/fileSystemService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L23">src/hostClients/fileSystemService.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">directory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L31">src/hostClients/fileSystemService.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L31">src/hostClients/fileSystemService.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemquerydirectoryresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L39">src/hostClients/fileSystemService.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L39">src/hostClients/fileSystemService.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileparams.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L35">src/hostClients/fileSystemService.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L35">src/hostClients/fileSystemService.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemqueryfileresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L59">src/hostClients/fileSystemService.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L59">src/hostClients/fileSystemService.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemservice.html
+++ b/ldk/node/docs/interfaces/filesystemservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L76">src/hostClients/fileSystemService.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L76">src/hostClients/fileSystemService.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L99">src/hostClients/fileSystemService.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L99">src/hostClients/fileSystemService.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L86">src/hostClients/fileSystemService.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L86">src/hostClients/fileSystemService.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L109">src/hostClients/fileSystemService.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L109">src/hostClients/fileSystemService.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamdirectoryresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L55">src/hostClients/fileSystemService.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L55">src/hostClients/fileSystemService.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">files<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L54">src/hostClients/fileSystemService.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L54">src/hostClients/fileSystemService.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
+++ b/ldk/node/docs/interfaces/filesystemstreamfileresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/filesystemstreamaction.html" class="tsd-signature-type">FileSystemStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L64">src/hostClients/fileSystemService.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L64">src/hostClients/fileSystemService.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<span class="tsd-signature-symbol">:</span> <a href="fileinfo.html" class="tsd-signature-type">FileInfo</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/fileSystemService.ts#L63">src/hostClients/fileSystemService.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/fileSystemService.ts#L63">src/hostClients/fileSystemService.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hostservices.html
+++ b/ldk/node/docs/interfaces/hostservices.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">clipboard<span class="tsd-signature-symbol">:</span> <a href="clipboardservice.html" class="tsd-signature-type">ClipboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L21">src/hostServices.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L21">src/hostServices.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">cursor<span class="tsd-signature-symbol">:</span> <a href="cursorservice.html" class="tsd-signature-type">CursorService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L22">src/hostServices.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L22">src/hostServices.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">file<wbr>System<span class="tsd-signature-symbol">:</span> <a href="filesystemservice.html" class="tsd-signature-type">FileSystemService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L23">src/hostServices.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L23">src/hostServices.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">keyboard<span class="tsd-signature-symbol">:</span> <a href="keyboardservice.html" class="tsd-signature-type">KeyboardService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L20">src/hostServices.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L20">src/hostServices.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="networkservice.html" class="tsd-signature-type">NetworkService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L25">src/hostServices.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L25">src/hostServices.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processservice.html" class="tsd-signature-type">ProcessService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L24">src/hostServices.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L24">src/hostServices.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">storage<span class="tsd-signature-symbol">:</span> <a href="storageservice.html" class="tsd-signature-type">StorageService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L19">src/hostServices.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L19">src/hostServices.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">whisper<span class="tsd-signature-symbol">:</span> <a href="whisperservice.html" class="tsd-signature-type">WhisperService</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostServices.ts#L18">src/hostServices.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostServices.ts#L18">src/hostServices.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyevent.html
+++ b/ldk/node/docs/interfaces/hotkeyevent.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"down"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"up"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L21">src/hostClients/keyboardService.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L21">src/hostClients/keyboardService.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hotkeyrequest.html
+++ b/ldk/node/docs/interfaces/hotkeyrequest.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L16">src/hostClients/keyboardService.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L16">src/hostClients/keyboardService.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">modifiers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="keyboardmodifiers.html" class="tsd-signature-type">KeyboardModifiers</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L17">src/hostClients/keyboardService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L17">src/hostClients/keyboardService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverreadrequest.html
+++ b/ldk/node/docs/interfaces/hoverreadrequest.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/hoverService.ts#L11">src/hostClients/hoverService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/hoverService.ts#L11">src/hostClients/hoverService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<wbr>From<wbr>Center<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/hoverService.ts#L12">src/hostClients/hoverService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/hoverService.ts#L12">src/hostClients/hoverService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverresponse.html
+++ b/ldk/node/docs/interfaces/hoverresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/hoverService.ts#L4">src/hostClients/hoverService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/hoverService.ts#L4">src/hostClients/hoverService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/hoverservice.html
+++ b/ldk/node/docs/interfaces/hoverservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/hoverService.ts#L25">src/hostClients/hoverService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/hoverService.ts#L25">src/hostClients/hoverService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/hoverService.ts#L34">src/hostClients/hoverService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/hoverService.ts#L34">src/hostClients/hoverService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/httprequest.html
+++ b/ldk/node/docs/interfaces/httprequest.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Uint8Array</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L4">src/hostClients/networkService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L4">src/hostClients/networkService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L3">src/hostClients/networkService.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L3">src/hostClients/networkService.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L2">src/hostClients/networkService.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L2">src/hostClients/networkService.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/httpresponse.html
+++ b/ldk/node/docs/interfaces/httpresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Uint8Array</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L9">src/hostClients/networkService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L9">src/hostClients/networkService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L8">src/hostClients/networkService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L8">src/hostClients/networkService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/keyboardmodifiers.html
+++ b/ldk/node/docs/interfaces/keyboardmodifiers.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">altL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L4">src/hostClients/keyboardService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L4">src/hostClients/keyboardService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">altR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L5">src/hostClients/keyboardService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L5">src/hostClients/keyboardService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L6">src/hostClients/keyboardService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L6">src/hostClients/keyboardService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">ctrlR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L7">src/hostClients/keyboardService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L7">src/hostClients/keyboardService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L8">src/hostClients/keyboardService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L8">src/hostClients/keyboardService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">metaR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L9">src/hostClients/keyboardService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L9">src/hostClients/keyboardService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L10">src/hostClients/keyboardService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L10">src/hostClients/keyboardService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">shiftR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L11">src/hostClients/keyboardService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L11">src/hostClients/keyboardService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/keyboardservice.html
+++ b/ldk/node/docs/interfaces/keyboardservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L49">src/hostClients/keyboardService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L49">src/hostClients/keyboardService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L68">src/hostClients/keyboardService.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L68">src/hostClients/keyboardService.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L56">src/hostClients/keyboardService.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L56">src/hostClients/keyboardService.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L42">src/hostClients/keyboardService.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L42">src/hostClients/keyboardService.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/loop.html
+++ b/ldk/node/docs/interfaces/loop.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/loop.ts#L34">src/loop.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/loop.ts#L34">src/loop.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/loop.ts#L39">src/loop.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/loop.ts#L39">src/loop.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/networkservice.html
+++ b/ldk/node/docs/interfaces/networkservice.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/networkService.ts#L13">src/hostClients/networkService.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/networkService.ts#L13">src/hostClients/networkService.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/interfaces/processinforesponse.html
+++ b/ldk/node/docs/interfaces/processinforesponse.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">arguments<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L13">src/hostClients/processService.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L13">src/hostClients/processService.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">command<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L12">src/hostClients/processService.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L12">src/hostClients/processService.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L11">src/hostClients/processService.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L11">src/hostClients/processService.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processlistresponse.html
+++ b/ldk/node/docs/interfaces/processlistresponse.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">processes<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L22">src/hostClients/processService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L22">src/hostClients/processService.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/processservice.html
+++ b/ldk/node/docs/interfaces/processservice.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L34">src/hostClients/processService.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L34">src/hostClients/processService.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L41">src/hostClients/processService.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L41">src/hostClients/processService.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/processstreamresponse.html
+++ b/ldk/node/docs/interfaces/processstreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/processstreamaction.html" class="tsd-signature-type">ProcessStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L18">src/hostClients/processService.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L18">src/hostClients/processService.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">process<span class="tsd-signature-symbol">:</span> <a href="processinforesponse.html" class="tsd-signature-type">ProcessInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/processService.ts#L17">src/hostClients/processService.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/processService.ts#L17">src/hostClients/processService.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/scancodeevent.html
+++ b/ldk/node/docs/interfaces/scancodeevent.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"up"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"down"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L30">src/hostClients/keyboardService.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L30">src/hostClients/keyboardService.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">scan<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L29">src/hostClients/keyboardService.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L29">src/hostClients/keyboardService.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/stoppablemessage.html
+++ b/ldk/node/docs/interfaces/stoppablemessage.html
@@ -78,6 +78,11 @@
 				<ul class="tsd-type-parameters">
 					<li>
 						<h4>T</h4>
+						<div class="tsd-comment tsd-typography">
+							<div class="lead">
+								<p>The type of the messages sent.</p>
+							</div>
+						</div>
 					</li>
 				</ul>
 			</section>
@@ -121,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/stoppables.ts#L22">src/hostClients/stoppables.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/stoppables.ts#L28">src/hostClients/stoppables.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -138,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/stoppables.ts#L20">src/hostClients/stoppables.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/stoppables.ts#L26">src/hostClients/stoppables.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/ldk/node/docs/interfaces/stoppablestream.html
+++ b/ldk/node/docs/interfaces/stoppablestream.html
@@ -65,11 +65,20 @@
 <div class="container container-main">
 	<div class="row">
 		<div class="col-8 col-content">
+			<section class="tsd-panel tsd-comment">
+				<div class="tsd-comment tsd-typography">
+				</div>
+			</section>
 			<section class="tsd-panel tsd-type-parameters">
 				<h3>Type parameters</h3>
 				<ul class="tsd-type-parameters">
 					<li>
 						<h4>T</h4>
+						<div class="tsd-comment tsd-typography">
+							<div class="lead">
+								<p>The type of the messages sent.</p>
+							</div>
+						</div>
 					</li>
 				</ul>
 			</section>
@@ -107,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/stoppables.ts#L12">src/hostClients/stoppables.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/stoppables.ts#L16">src/hostClients/stoppables.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -130,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/stoppables.ts#L10">src/hostClients/stoppables.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/stoppables.ts#L14">src/hostClients/stoppables.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/ldk/node/docs/interfaces/storageservice.html
+++ b/ldk/node/docs/interfaces/storageservice.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L9">src/hostClients/storageService.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L9">src/hostClients/storageService.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L14">src/hostClients/storageService.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L14">src/hostClients/storageService.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L20">src/hostClients/storageService.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L20">src/hostClients/storageService.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L25">src/hostClients/storageService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L25">src/hostClients/storageService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L33">src/hostClients/storageService.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L33">src/hostClients/storageService.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L40">src/hostClients/storageService.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L40">src/hostClients/storageService.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/storageService.ts#L49">src/hostClients/storageService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/storageService.ts#L49">src/hostClients/storageService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/textstream.html
+++ b/ldk/node/docs/interfaces/textstream.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/keyboardService.ts#L25">src/hostClients/keyboardService.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/keyboardService.ts#L25">src/hostClients/keyboardService.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/uiservice.html
+++ b/ldk/node/docs/interfaces/uiservice.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/uiService.ts#L5">src/hostClients/uiService.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/uiService.ts#L5">src/hostClients/uiService.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/uiService.ts#L4">src/hostClients/uiService.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/uiService.ts#L4">src/hostClients/uiService.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/ldk/node/docs/interfaces/whisper.html
+++ b/ldk/node/docs/interfaces/whisper.html
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperconfirmconfig.html
+++ b/ldk/node/docs/interfaces/whisperconfirmconfig.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">reject<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L133">src/hostClients/whisperService.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L133">src/hostClients/whisperService.ts:133</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">resolve<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L135">src/hostClients/whisperService.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L135">src/hostClients/whisperService.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperformconfig.html
+++ b/ldk/node/docs/interfaces/whisperformconfig.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L141">src/hostClients/whisperService.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L141">src/hostClients/whisperService.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#icon">icon</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L57">src/hostClients/whisperService.ts:57</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">inputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L143">src/hostClients/whisperService.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L143">src/hostClients/whisperService.ts:143</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L61">src/hostClients/whisperService.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#markdown">markdown</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L53">src/hostClients/whisperService.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisper.html">Whisper</a>.<a href="whisper.html#style">style</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L65">src/hostClients/whisperService.ts:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">submit<wbr>Button<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L139">src/hostClients/whisperService.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L139">src/hostClients/whisperService.ts:139</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminput.html
+++ b/ldk/node/docs/interfaces/whisperforminput.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L69">src/hostClients/whisperService.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L69">src/hostClients/whisperService.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L77">src/hostClients/whisperService.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L77">src/hostClients/whisperService.ts:77</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">tooltip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L70">src/hostClients/whisperService.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L70">src/hostClients/whisperService.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L71">src/hostClients/whisperService.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L71">src/hostClients/whisperService.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperforminputwithvalue.html
+++ b/ldk/node/docs/interfaces/whisperforminputwithvalue.html
@@ -115,7 +115,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#label">label</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L69">src/hostClients/whisperService.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L69">src/hostClients/whisperService.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#order">order</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L77">src/hostClients/whisperService.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L77">src/hostClients/whisperService.ts:77</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#tooltip">tooltip</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L70">src/hostClients/whisperService.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L70">src/hostClients/whisperService.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="whisperforminput.html">WhisperFormInput</a>.<a href="whisperforminput.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L71">src/hostClients/whisperService.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L71">src/hostClients/whisperService.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L82">src/hostClients/whisperService.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L82">src/hostClients/whisperService.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformsubmitevent.html
+++ b/ldk/node/docs/interfaces/whisperformsubmitevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">outputs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L156">src/hostClients/whisperService.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L156">src/hostClients/whisperService.ts:156</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">submitted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L155">src/hostClients/whisperService.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L155">src/hostClients/whisperService.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"submit"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L157">src/hostClients/whisperService.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L157">src/hostClients/whisperService.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperformupdateevent.html
+++ b/ldk/node/docs/interfaces/whisperformupdateevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L149">src/hostClients/whisperService.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L149">src/hostClients/whisperService.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L151">src/hostClients/whisperService.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L151">src/hostClients/whisperService.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../globals.html#whisperformoutputtypes" class="tsd-signature-type">WhisperFormOutputTypes</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L150">src/hostClients/whisperService.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L150">src/hostClients/whisperService.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/whisperservice.html
+++ b/ldk/node/docs/interfaces/whisperservice.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L171">src/hostClients/whisperService.ts:171</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L171">src/hostClients/whisperService.ts:171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L173">src/hostClients/whisperService.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L173">src/hostClients/whisperService.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L167">src/hostClients/whisperService.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L167">src/hostClients/whisperService.ts:167</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/whisperstyle.html
+++ b/ldk/node/docs/interfaces/whisperstyle.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L22">src/hostClients/whisperService.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L22">src/hostClients/whisperService.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L26">src/hostClients/whisperService.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L26">src/hostClients/whisperService.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/whisperService.ts#L30">src/hostClients/whisperService.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/whisperService.ts#L30">src/hostClients/whisperService.ts:30</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/ldk/node/docs/interfaces/windowinforesponse.html
+++ b/ldk/node/docs/interfaces/windowinforesponse.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L10">src/hostClients/windowService.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L10">src/hostClients/windowService.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L5">src/hostClients/windowService.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L5">src/hostClients/windowService.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L6">src/hostClients/windowService.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L6">src/hostClients/windowService.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">title<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L4">src/hostClients/windowService.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L4">src/hostClients/windowService.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L9">src/hostClients/windowService.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L9">src/hostClients/windowService.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L7">src/hostClients/windowService.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L7">src/hostClients/windowService.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L8">src/hostClients/windowService.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L8">src/hostClients/windowService.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowinfostreamresponse.html
+++ b/ldk/node/docs/interfaces/windowinfostreamresponse.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">action<span class="tsd-signature-symbol">:</span> <a href="../enums/windowstreamaction.html" class="tsd-signature-type">WindowStreamAction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L24">src/hostClients/windowService.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L24">src/hostClients/windowService.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <a href="windowinforesponse.html" class="tsd-signature-type">WindowInfoResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L23">src/hostClients/windowService.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L23">src/hostClients/windowService.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/ldk/node/docs/interfaces/windowservice.html
+++ b/ldk/node/docs/interfaces/windowservice.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L36">src/hostClients/windowService.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L36">src/hostClients/windowService.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L43">src/hostClients/windowService.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L43">src/hostClients/windowService.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L50">src/hostClients/windowService.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L50">src/hostClients/windowService.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/0c0c530/ldk/node/src/hostClients/windowService.ts#L59">src/hostClients/windowService.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit/blob/3bbb1d0/ldk/node/src/hostClients/windowService.ts#L59">src/hostClients/windowService.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/ldk/node/src/hostClients/stoppables.ts
+++ b/ldk/node/src/hostClients/stoppables.ts
@@ -1,11 +1,15 @@
 /**
  * The StreamListener type is a function provided to start a stream. It accepts two parameters and returns nothing.
  *
+ * @template T - The type of the messages sent.
  * @param error - Null, unless an error is present.
  * @param input - The event that's being generated.
  */
 export type StreamListener<T> = (error: string | null, input?: T) => void;
 
+/**
+ * @template T - The type of the messages sent.
+ */
 export interface StoppableStream<T> {
   stop(): void;
 
@@ -15,6 +19,8 @@ export interface StoppableStream<T> {
 /**
  * The StoppableMessage interface provides access to a promise that resolves when the message completes, and
  * to the ability to stop the message.
+ *
+ * @template T - The type of the messages sent.
  */
 export interface StoppableMessage<T> {
   stop(): void;


### PR DESCRIPTION
Addressing @richseviora's feedback [here](https://github.com/open-olive/loop-development-kit/pull/15#discussion_r523056832).

The `@template` tag [seems to be supported](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template) for TypeScript/JSDoc.