### PR TITLE
fix for bad access: nil dereference

### DIFF
--- a/ldk/go/uiClient.go
+++ b/ldk/go/uiClient.go
@@ -29,11 +29,7 @@ func (u *UIClient) ListenSearchbar(ctx context.Context, handler ListenSearchHand
 				break
 			}
 			if err != nil {
-				message := "Error with SearchbarStream"
-				if resp != nil {
-					message = resp.Text
-				}
-				handler(message, err)
+				handler("", err)
 				return
 			}
 			if resp.GetError() != "" {
@@ -62,11 +58,7 @@ func (u *UIClient) ListenGlobalSearch(ctx context.Context, handler ListenSearchH
 				break
 			}
 			if err != nil {
-				message := "Error with GlobalSearchStream"
-				if resp != nil {
-					message = resp.Text
-				}
-				handler(message, err)
+				handler("", err)
 				return
 			}
 			if resp.GetError() != "" {

--- a/ldk/go/uiClient.go
+++ b/ldk/go/uiClient.go
@@ -29,7 +29,11 @@ func (u *UIClient) ListenSearchbar(ctx context.Context, handler ListenSearchHand
 				break
 			}
 			if err != nil {
-				handler(resp.Text, err)
+				message := "Error with SearchbarStream"
+				if resp != nil {
+					message = resp.Text
+				}
+				handler(message, err)
 				return
 			}
 			if resp.GetError() != "" {
@@ -58,7 +62,11 @@ func (u *UIClient) ListenGlobalSearch(ctx context.Context, handler ListenSearchH
 				break
 			}
 			if err != nil {
-				handler(resp.Text, err)
+				message := "Error with GlobalSearchStream"
+				if resp != nil {
+					message = resp.Text
+				}
+				handler(message, err)
 				return
 			}
 			if resp.GetError() != "" {


### PR DESCRIPTION
Bugfix for when Loops are attempting to be gracefully shutdown, the global/searchbar on teardown were getting a fatal error: `bad access: nil dereference`

Found while debugging [SIDE-1021](https://crosschx.atlassian.net/browse/SIDE-1021)