### PR TITLE
[SIDE-1045] Correct linting rule, remove unnecessary disables

### DIFF
--- a/ldk/node/.eslintrc.js
+++ b/ldk/node/.eslintrc.js
@@ -36,6 +36,10 @@ module.exports = {
           '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
+    // The no-shadow rule set in airbnb-base generates false positives with TS.
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
     'no-underscore-dangle': 'off',
     'no-console': ['off', { allow: ['warn', 'error'] }],
     'unicode-bom': 'off',

--- a/ldk/node/dist/access.js
+++ b/ldk/node/dist/access.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Access = void 0;
-// eslint-disable-next-line no-shadow
 var Access;
 (function (Access) {
     Access["ORGANIZATION"] = "organization";

--- a/ldk/node/dist/brokerGrpcServer.d.ts
+++ b/ldk/node/dist/brokerGrpcServer.d.ts
@@ -25,9 +25,7 @@ export default class BrokerGrpcServer {
     /**
      * Start a connection info stream from the host process.
      *
-     * @param connInfoCallback
-     * - The callback that handles receiving connection info.
-     * @param call
+     * @param call - The callback that handles receiving connection info.
      */
     startStream: grpc.handleBidiStreamingCall<ConnInfo, ConnInfo>;
     /**

--- a/ldk/node/dist/brokerGrpcServer.js
+++ b/ldk/node/dist/brokerGrpcServer.js
@@ -27,9 +27,7 @@ class BrokerGrpcServer {
         /**
          * Start a connection info stream from the host process.
          *
-         * @param connInfoCallback
-         * - The callback that handles receiving connection info.
-         * @param call
+         * @param call - The callback that handles receiving connection info.
          */
         this.startStream = (call) => {
             call.on('data', (msg) => {

--- a/ldk/node/dist/categories.js
+++ b/ldk/node/dist/categories.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.categories = exports.Category = void 0;
-// eslint-disable-next-line no-shadow
 var Category;
 (function (Category) {
     Category["CONTROLLER"] = "Controller";

--- a/ldk/node/dist/hostClients/fileSystemService.js
+++ b/ldk/node/dist/hostClients/fileSystemService.js
@@ -1,8 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FileSystemStreamAction = void 0;
-// This rule is triggering for some reason.
-// eslint-disable-next-line no-shadow
 var FileSystemStreamAction;
 (function (FileSystemStreamAction) {
     FileSystemStreamAction["Unknown"] = "unknown";

--- a/ldk/node/dist/hostClients/processService.js
+++ b/ldk/node/dist/hostClients/processService.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ProcessStreamAction = void 0;
-// eslint-disable-next-line no-shadow
 var ProcessStreamAction;
 (function (ProcessStreamAction) {
     ProcessStreamAction["Unknown"] = "unknown";

--- a/ldk/node/dist/hostClients/whisperService.js
+++ b/ldk/node/dist/hostClients/whisperService.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.WhisperListAlign = exports.WhisperListStyle = void 0;
-// eslint-disable-next-line no-shadow
 var WhisperListStyle;
 (function (WhisperListStyle) {
     WhisperListStyle[WhisperListStyle["NONE"] = 0] = "NONE";
@@ -9,7 +8,6 @@ var WhisperListStyle;
     WhisperListStyle[WhisperListStyle["WARN"] = 2] = "WARN";
     WhisperListStyle[WhisperListStyle["ERROR"] = 3] = "ERROR";
 })(WhisperListStyle = exports.WhisperListStyle || (exports.WhisperListStyle = {}));
-// eslint-disable-next-line no-shadow
 var WhisperListAlign;
 (function (WhisperListAlign) {
     WhisperListAlign[WhisperListAlign["LEFT"] = 0] = "LEFT";

--- a/ldk/node/dist/hostClients/windowService.js
+++ b/ldk/node/dist/hostClients/windowService.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.WindowStreamAction = void 0;
-// eslint-disable-next-line no-shadow
 var WindowStreamAction;
 (function (WindowStreamAction) {
     WindowStreamAction["Unknown"] = "unknown";

--- a/ldk/node/dist/logging.js
+++ b/ldk/node/dist/logging.js
@@ -11,7 +11,6 @@ const pid = process.pid;
 /**
  * @internal
  */
-// eslint-disable-next-line no-shadow
 var LogLevels;
 (function (LogLevels) {
     LogLevels["TRACE"] = "TRACE";

--- a/ldk/node/dist/operatingSystem.js
+++ b/ldk/node/dist/operatingSystem.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.OperatingSystem = void 0;
-// eslint-disable-next-line no-shadow
 var OperatingSystem;
 (function (OperatingSystem) {
     OperatingSystem["ANY"] = "any";

--- a/ldk/node/src/access.ts
+++ b/ldk/node/src/access.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-shadow
 export enum Access {
   ORGANIZATION = 'organization',
   PUBLIC = 'public',

--- a/ldk/node/src/brokerGrpcServer.ts
+++ b/ldk/node/src/brokerGrpcServer.ts
@@ -1,7 +1,6 @@
 import * as grpc from '@grpc/grpc-js';
 import services from './grpc/broker_grpc_pb';
 import { ConnInfo } from './grpc/broker_pb';
-import { Logger } from './logging';
 
 /**
  * Class used to interact with the broker GRPC service.
@@ -41,9 +40,7 @@ export default class BrokerGrpcServer {
   /**
    * Start a connection info stream from the host process.
    *
-   * @param connInfoCallback
-   * - The callback that handles receiving connection info.
-   * @param call
+   * @param call - The callback that handles receiving connection info.
    */
   startStream: grpc.handleBidiStreamingCall<ConnInfo, ConnInfo> = (call) => {
     call.on('data', (msg: ConnInfo) => {

--- a/ldk/node/src/categories.ts
+++ b/ldk/node/src/categories.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-shadow
 export enum Category {
   CONTROLLER = 'Controller',
   INTELLIGENCE = 'Intelligence',

--- a/ldk/node/src/hostClients/fileSystemService.ts
+++ b/ldk/node/src/hostClients/fileSystemService.ts
@@ -39,8 +39,6 @@ export interface FileSystemQueryDirectoryResponse {
   files: FileInfo[];
 }
 
-// This rule is triggering for some reason.
-// eslint-disable-next-line no-shadow
 export enum FileSystemStreamAction {
   Unknown = 'unknown',
   Create = 'create',

--- a/ldk/node/src/hostClients/processService.ts
+++ b/ldk/node/src/hostClients/processService.ts
@@ -1,6 +1,5 @@
 import { StoppableStream, StreamListener } from './stoppables';
 
-// eslint-disable-next-line no-shadow
 export enum ProcessStreamAction {
   Unknown = 'unknown',
   Started = 'started',

--- a/ldk/node/src/hostClients/whisperService.ts
+++ b/ldk/node/src/hostClients/whisperService.ts
@@ -121,7 +121,6 @@ export interface WhisperListElement<T extends string> {
   order?: number;
 }
 
-// eslint-disable-next-line no-shadow
 export enum WhisperListStyle {
   NONE = 0,
   SUCCESS,
@@ -129,7 +128,6 @@ export enum WhisperListStyle {
   ERROR,
 }
 
-// eslint-disable-next-line no-shadow
 export enum WhisperListAlign {
   LEFT = 0,
   CENTER,

--- a/ldk/node/src/hostClients/windowService.ts
+++ b/ldk/node/src/hostClients/windowService.ts
@@ -10,7 +10,6 @@ export interface WindowInfoResponse {
   height: number;
 }
 
-// eslint-disable-next-line no-shadow
 export enum WindowStreamAction {
   Unknown = 'unknown',
   Focused = 'focused',

--- a/ldk/node/src/logging.ts
+++ b/ldk/node/src/logging.ts
@@ -10,7 +10,6 @@ const pid = process.pid;
 /**
  * @internal
  */
-// eslint-disable-next-line no-shadow
 enum LogLevels {
   TRACE = 'TRACE',
   DEBUG = 'DEBUG',

--- a/ldk/node/src/operatingSystem.ts
+++ b/ldk/node/src/operatingSystem.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-shadow
 export enum OperatingSystem {
   ANY = 'any',
   LINUX = 'linux',


### PR DESCRIPTION
This PR fixes a bug with our linting configuration that was generating false positives on the `no-shadow` rule. It turns out that that rule does not work with Typescript files, and we need to use the one from `@typescript-eslint` instead.

Also fixes minor linting complaints in `src/brokerGrpcServer.ts` file.