### PR TITLE
[SIDE-1154] Implement Filesystem Changes in .Net and Node LDKs

### DIFF
--- a/ldk/csharp/OliveHelpsLDK/Example/Program.cs
+++ b/ldk/csharp/OliveHelpsLDK/Example/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OliveHelpsLDK;
@@ -34,6 +35,11 @@ namespace Example
         public static void Main(string[] args)
         {
             ILogger logger = new Logger("csharp-clipboard-example");
+            TaskScheduler.UnobservedTaskException += (sender, eventArgs) =>
+            {
+                logger.Error("Unhandled Task Exception",
+                    new Dictionary<string, object>() {{"error", eventArgs.Exception}});
+            };
             LoopServer.Start(new Loop
             {
                 Logger = logger
@@ -68,6 +74,7 @@ namespace Example
         private void ClipboardStream()
         {
             _clipboardStream = _services.Clipboard.Stream();
+            Logger.Info("Started Streaming Clipboard");
             Task.Run(async () =>
             {
                 await foreach (var clipboardContent in _clipboardStream.ToAsyncEnumerable())
@@ -77,6 +84,25 @@ namespace Example
                         Logger.Info($"Received Clipboard Update \"{clipboardContent}\"");
                         switch (clipboardContent)
                         {
+                            case "fileinfo":
+                                Logger.Info("Starting File Info");
+                                try
+                                {
+                                    var fileInfoStream = FileInfoStream();
+                                    fileInfoStream.ContinueWith(
+                                        continuationAction: (task =>
+                                        {
+                                            Logger.Error("Handled Exception", task.Exception);
+                                        }), TaskContinuationOptions.OnlyOnFaulted);
+                                    // fileInfoStream.Wait();
+                                }
+                                catch (Exception e)
+                                {
+                                    Logger.Error("Exception Caught",
+                                        new Dictionary<string, object>() {{"error", e.ToString()}});
+                                }
+
+                                break;
                             case "formnew":
                                 FormStream();
                                 Logger.Info("Starting Form Stream");
@@ -160,13 +186,27 @@ namespace Example
             ccs.CancelAfter(5000);
             _services.Whisper.MarkdownAsync(new WhisperMarkdown
             {
-                Markdown = $"Clipboard Content {content}",
+                Markdown = content,
                 Config = new WhisperConfig
                 {
                     Label = "C# Whisper"
                 }
             }, ccs.Token);
-            Logger.Info($"Sent Clipboard Update {content}");
+            Logger.Info($"Sent Whisper {content}");
+        }
+
+        private async Task FileInfoStream()
+        {
+            var file = await _services.Filesystem.OpenFile("/tmp/log3.txt");
+            Logger.Info("Requesting File Info");
+            var fileInfo = await file.FileInfo();
+            Logger.Info($"Received File Info - {fileInfo.ToString()}",
+                new Dictionary<string, object>() {{"file", fileInfo.ToString()}});
+            await file.Close();
+            Logger.Info("File Closed");
+            var fileInfoJson = JsonSerializer.Serialize(fileInfo);
+            Logger.Info(fileInfoJson);
+            EmitWhisper(fileInfoJson);
         }
 
         private void EmitListWhisper()

--- a/ldk/csharp/OliveHelpsLDK/Example/Program.cs
+++ b/ldk/csharp/OliveHelpsLDK/Example/Program.cs
@@ -94,7 +94,6 @@ namespace Example
                                         {
                                             Logger.Error("Handled Exception", task.Exception);
                                         }), TaskContinuationOptions.OnlyOnFaulted);
-                                    // fileInfoStream.Wait();
                                 }
                                 catch (Exception e)
                                 {

--- a/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/File.cs
+++ b/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/File.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Grpc.Core;
+using OliveHelpsLDK.Logging;
+using Proto;
+
+namespace OliveHelpsLDK.Filesystem
+{
+    internal enum FileStatus
+    {
+        Pending,
+        Initialized,
+        Closed
+    }
+
+    internal class File : IFile
+    {
+        internal AsyncDuplexStreamingCall<FilesystemFileStreamRequest, FilesystemFileStreamResponse> Stream { get; }
+        private Session Session { get; }
+
+        private ILogger Logger { get; set; }
+
+        private string Path { get; set; }
+
+        private FileStatus Status { get; set; }
+
+        internal File(AsyncDuplexStreamingCall<FilesystemFileStreamRequest, FilesystemFileStreamResponse> stream,
+            ILogger logger, Session session)
+        {
+            Stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            Logger = logger;
+            Session = session;
+            Status = FileStatus.Pending;
+        }
+
+        internal Task Open(string path)
+        {
+            Path = path;
+            Logger = Logger.WithFields(new Dictionary<string, object>() {{"path", path}});
+            var request = new FilesystemFileStreamRequest
+            {
+                Open = new FilesystemFileStreamRequest.Types.Open()
+                {
+                    Path = path,
+                    Session = CreateSession()
+                }
+            };
+            CheckStatus(true);
+            Status = FileStatus.Initialized;
+            return WriteToStream(request);
+        }
+
+        internal Task Create(string path)
+        {
+            Path = path;
+            Logger = Logger.WithFields(new Dictionary<string, object>() {{"path", path}});
+            var request = new FilesystemFileStreamRequest
+            {
+                Create = new FilesystemFileStreamRequest.Types.Create()
+                {
+                    Path = path,
+                    Session = CreateSession()
+                }
+            };
+            CheckStatus(true);
+            Status = FileStatus.Initialized;
+            return WriteToStream(request);
+        }
+
+        public Task<int> Write(byte[] data)
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Write = new FilesystemFileStreamRequest.Types.Write()
+                {
+                    Data = ByteString.CopyFrom(data)
+                },
+            };
+            return WriteAndReceive(message,
+                response => response.Write,
+                read => read.NumOfBytes);
+        }
+
+        public Task<byte[]> Read()
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Read = new FilesystemFileStreamRequest.Types.Read() { },
+            };
+            return WriteAndReceive(message,
+                response => response.Read,
+                read => read.Data.ToByteArray());
+        }
+
+        public Task Close()
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Close = new FilesystemFileStreamRequest.Types.Close() { },
+            };
+            CheckStatus();
+            return WriteToStream(message);
+        }
+
+        public Task ChangePermissions(int permission)
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Chmod = new FilesystemFileStreamRequest.Types.Chmod()
+                {
+                    Mode = (uint) permission
+                },
+            };
+            return WriteAndReceive(message,
+                response => response.Chmod,
+                (_) => true);
+        }
+
+        public Task ChangeOwnership(int userId, int groupId)
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Chown = new FilesystemFileStreamRequest.Types.Chown()
+                {
+                    Uid = userId,
+                    Gid = groupId
+                },
+            };
+            return WriteAndReceive(message,
+                response => response.Chown,
+                (_) => true);
+        }
+
+        public Task<FileInfo> FileInfo()
+        {
+            var message = new FilesystemFileStreamRequest()
+            {
+                Stat = new FilesystemFileStreamRequest.Types.Stat() { },
+            };
+            return WriteAndReceive(message,
+                response => response.Stat,
+                ConvertProtoFileInfo
+            );
+        }
+
+
+        protected Proto.Session CreateSession()
+        {
+            return new Proto.Session
+            {
+                LoopID = Session.LoopId,
+                Token = Session.Token,
+            };
+        }
+
+        protected async Task<TOutput> WriteAndReceive<TResponse, TOutput>(Proto.FilesystemFileStreamRequest request,
+            Func<Proto.FilesystemFileStreamResponse, TResponse> responseReader,
+            Func<TResponse, TOutput> transformer,
+            [CallerMemberName] string caller = ""
+        )
+        {
+            CheckStatus();
+            await WriteToStream(request);
+            bool moveNext = false;
+            try
+            {
+                moveNext = await Stream.ResponseStream.MoveNext();
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Duplex Response - Error on Move Next", e);
+                throw e;
+            }
+
+            if (!moveNext)
+            {
+                throw new Exception("Could Not Move Next");
+            }
+
+
+            try
+            {
+                Logger.Trace($"Duplex Response - {caller} - Receiving");
+                var message = Stream.ResponseStream.Current;
+                var response = responseReader(message);
+                Logger.Trace($"Duplex Response - {caller} -Transforming");
+                var output = transformer(response);
+                Logger.Trace($"Duplex Response - {caller} - Completing",
+                    new Dictionary<string, object>() {{"output", output.ToString()}});
+                return output;
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Duplex Response - {caller} - Throwing, Error Received", e);
+                throw e;
+            }
+        }
+
+        private void CheckStatus(bool expectPending = false)
+        {
+            if (expectPending && Status != FileStatus.Pending)
+            {
+                Logger.Error("File Stream is expecting to be pending, but isn't");
+                throw new Exception("File is not pending");
+            }
+
+            if (expectPending)
+            {
+                return;
+            }
+
+            if (Status == FileStatus.Initialized) return;
+            Logger.Error("Message sent to closed file stream");
+            throw new Exception("File Stream has been closed, cannot send additional messages");
+        }
+
+        private async Task WriteToStream(FilesystemFileStreamRequest request)
+        {
+            try
+            {
+                Logger.Trace("Duplex Request - Sending");
+                await Stream.RequestStream.WriteAsync(request);
+                Logger.Trace("Duplex Request - Sent");
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Duplex Request - Error Thrown", e);
+                throw e;
+            }
+        }
+
+        private FileInfo ConvertProtoFileInfo(Proto.FilesystemFileStreamResponse.Types.Stat stat)
+        {
+            var info = stat.Info;
+            Logger.Trace(info.ToString());
+            return new FileInfo
+            {
+                IsDirectory = info.IsDir,
+                Name = info.Name,
+                Mode = info.Mode,
+                Size = info.Size,
+                Updated = info.Updated.ToDateTime(),
+            };
+        }
+    }
+}

--- a/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/FilesystemClient.cs
+++ b/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/FilesystemClient.cs
@@ -63,6 +63,66 @@ namespace OliveHelpsLDK.Filesystem
             return new StreamingCall<FilesystemFileInfoStreamResponse, FileEvent>(call, loggedParser);
         }
 
+        public Task MakeDirectory(MakeDirectoryParameters parameters, CancellationToken cancellationToken = default)
+        {
+            var request = new FilesystemMakeDirRequest
+            {
+                Session = CreateSession(),
+                Path = parameters.Path,
+                Perm = parameters.Permissions
+            };
+            return Client.FilesystemMakeDirAsync(request, CreateOptions(cancellationToken)).ResponseAsync;
+        }
+
+        public Task Copy(MoveOrCopyFileParameters parameters, CancellationToken cancellationToken = default)
+        {
+            var request = new FilesystemCopyRequest()
+            {
+                Session = CreateSession(),
+                Source = parameters.Source,
+                Dest = parameters.Destination
+            };
+            return Client.FilesystemCopyAsync(request, CreateOptions(cancellationToken)).ResponseAsync;
+        }
+
+        public Task Move(MoveOrCopyFileParameters parameters, CancellationToken cancellationToken = default)
+        {
+            var request = new FilesystemMoveRequest()
+            {
+                Session = CreateSession(),
+                Source = parameters.Source,
+                Dest = parameters.Destination
+            };
+            return Client.FilesystemMoveAsync(request, CreateOptions(cancellationToken)).ResponseAsync;
+        }
+
+        public Task Remove(RemoveParameters parameters, CancellationToken cancellationToken = default)
+        {
+            var request = new FilesystemRemoveRequest()
+            {
+                Session = CreateSession(),
+                Path = parameters.Path,
+                Recursive = parameters.Recursive
+            };
+            return Client.FilesystemRemoveAsync(request, CreateOptions(cancellationToken)).ResponseAsync;
+        }
+
+        public async Task<IFile> OpenFile(string path, CancellationToken cancellationToken = default)
+        {
+            var stream = Client.FilesystemFileStream(CreateOptions(cancellationToken));
+            var file = new File(stream, Logger, Session);
+            await file.Open(path);
+            return file;
+        }
+
+        public async Task<IFile> CreateFile(string path, CancellationToken cancellationToken = default)
+        {
+            var stream = Client.FilesystemFileStream(CreateOptions(cancellationToken));
+            var file = new File(stream, Logger, Session);
+            await file.Create(path);
+            return file;
+        }
+
         private static IList<FileInfo> ConvertFileList(IEnumerable<Proto.FileInfo> files)
         {
             return files.Select(ConvertProtoFileInfo).ToList();

--- a/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/IFilesystemService.cs
+++ b/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/IFilesystemService.cs
@@ -37,6 +37,11 @@ namespace OliveHelpsLDK.Filesystem
         Task ChangeOwnership(int userId, int groupId);
 
         Task<FileInfo> FileInfo();
+
+        /// <summary>
+        /// The CompletionTask completes when the stream is closed by the user. It set to faulted if the Stream encounters an error. 
+        /// </summary>
+        Task CompletionTask { get; }
     }
 
     public struct MakeDirectoryParameters

--- a/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/IFilesystemService.cs
+++ b/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Filesystem/IFilesystemService.cs
@@ -10,15 +10,60 @@ namespace OliveHelpsLDK.Filesystem
         Task<IList<FileInfo>> QueryDirectory(string directoryPath, CancellationToken cancellationToken = default);
         IStreamingCall<FileEvent> StreamDirectory(string directoryPath, CancellationToken cancellationToken = default);
         IStreamingCall<FileEvent> StreamFileInfo(string filePath, CancellationToken cancellationToken = default);
+
+        Task MakeDirectory(MakeDirectoryParameters parameters, CancellationToken cancellationToken = default);
+
+        Task Copy(MoveOrCopyFileParameters parameters, CancellationToken cancellationToken = default);
+
+        Task Move(MoveOrCopyFileParameters parameters, CancellationToken cancellationToken = default);
+
+        Task Remove(RemoveParameters parameters, CancellationToken cancellationToken = default);
+
+        Task<IFile> OpenFile(string path, CancellationToken cancellationToken = default);
+
+        Task<IFile> CreateFile(string path, CancellationToken cancellationToken = default);
+    }
+
+    public interface IFile
+    {
+        Task<int> Write(byte[] data);
+
+        Task<byte[]> Read();
+
+        Task Close();
+
+        Task ChangePermissions(int permission);
+
+        Task ChangeOwnership(int userId, int groupId);
+
+        Task<FileInfo> FileInfo();
+    }
+
+    public struct MakeDirectoryParameters
+    {
+        public string Path;
+        public uint Permissions;
+    }
+
+    public struct MoveOrCopyFileParameters
+    {
+        public string Source;
+        public string Destination;
+    }
+
+    public struct RemoveParameters
+    {
+        public string Path;
+        public bool Recursive;
     }
 
     public struct FileInfo
     {
-        public string Name;
-        public long Size;
-        public uint Mode;
-        public DateTime Updated;
-        public bool IsDirectory;
+        public string Name { get; set; }
+        public long Size { get; set; }
+        public uint Mode { get; set; }
+        public DateTime Updated { get; set; }
+        public bool IsDirectory { get; set; }
     }
 
     public enum FileAction

--- a/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Logging/ILogger.cs
+++ b/ldk/csharp/OliveHelpsLDK/OliveHelpsLDK/Logging/ILogger.cs
@@ -15,5 +15,6 @@ namespace OliveHelpsLDK.Logging
         void Error(string message, Exception exception);
 
         ILogger WithFields(IDictionary<string, object> fields);
+
     }
 }

--- a/ldk/go/filesystemServer.go
+++ b/ldk/go/filesystemServer.go
@@ -191,6 +191,9 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 					return err
 				}
 
+			case *proto.FilesystemFileStreamRequest_Close_:
+			    return nil
+
 			case *proto.FilesystemFileStreamRequest_Create_:
 				session, err := NewSessionFromProto(req.Create.Session)
 				if err != nil {

--- a/ldk/go/filesystemServer.go
+++ b/ldk/go/filesystemServer.go
@@ -162,9 +162,7 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 		if file != nil {
 			file.Close()
 		}
-		fmt.Println("Closing File Stream")
 	}()
-    fmt.Println("Starting File Stream")
 	for {
 		select {
 		case <-stream.Context().Done():
@@ -186,13 +184,9 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 					context.WithValue(stream.Context(), Session{}, session),
 					req.Open.GetPath(),
 				)
-                fmt.Println("Opened File Stream");
 				if err != nil {
 					return err
 				}
-
-			case *proto.FilesystemFileStreamRequest_Close_:
-			    return nil
 
 			case *proto.FilesystemFileStreamRequest_Create_:
 				session, err := NewSessionFromProto(req.Create.Session)
@@ -296,7 +290,6 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 				if file == nil {
 					return ErrNoFile
 				}
-				fmt.Println("Request File Info");
 				var errorResponse string
 				info, err := file.Stat()
 				if err != nil {
@@ -306,7 +299,6 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 				if err != nil {
 					errorResponse = err.Error()
 				}
-				fmt.Println("Sending File Info");
 				err = stream.Send(&proto.FilesystemFileStreamResponse{
 					ResponseOneOf: &proto.FilesystemFileStreamResponse_Stat_{
 						Stat: &proto.FilesystemFileStreamResponse_Stat{
@@ -321,9 +313,8 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 						},
 					},
 				})
-				fmt.Println("File Info Sent");
 				if err != nil {
-				    fmt.Println("Returning with Error", err);
+					fmt.Println("Returning with Error", err)
 					return err
 				}
 

--- a/ldk/go/filesystemServer.go
+++ b/ldk/go/filesystemServer.go
@@ -162,8 +162,9 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 		if file != nil {
 			file.Close()
 		}
+		fmt.Println("Closing File Stream")
 	}()
-
+    fmt.Println("Starting File Stream")
 	for {
 		select {
 		case <-stream.Context().Done():
@@ -185,7 +186,7 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 					context.WithValue(stream.Context(), Session{}, session),
 					req.Open.GetPath(),
 				)
-
+                fmt.Println("Opened File Stream");
 				if err != nil {
 					return err
 				}
@@ -292,6 +293,7 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 				if file == nil {
 					return ErrNoFile
 				}
+				fmt.Println("Request File Info");
 				var errorResponse string
 				info, err := file.Stat()
 				if err != nil {
@@ -301,6 +303,7 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 				if err != nil {
 					errorResponse = err.Error()
 				}
+				fmt.Println("Sending File Info");
 				err = stream.Send(&proto.FilesystemFileStreamResponse{
 					ResponseOneOf: &proto.FilesystemFileStreamResponse_Stat_{
 						Stat: &proto.FilesystemFileStreamResponse_Stat{
@@ -315,7 +318,9 @@ func (f *FilesystemServer) FilesystemFileStream(stream proto.Filesystem_Filesyst
 						},
 					},
 				})
+				fmt.Println("File Info Sent");
 				if err != nil {
+				    fmt.Println("Returning with Error", err);
 					return err
 				}
 

--- a/ldk/node/dist/hostClients/baseClient.d.ts
+++ b/ldk/node/dist/hostClients/baseClient.d.ts
@@ -4,7 +4,7 @@ import { CommonHostServer } from '../commonHostServer';
 import { CommonHostClient } from './commonHostClient';
 import { Session } from '../grpc/session_pb';
 import { StoppableMessage } from './stoppables';
-import { Logger } from '../logging';
+import { ILogger } from '../logging';
 /**
  * @internal
  */
@@ -42,7 +42,7 @@ export default abstract class BaseClient<THost extends CommonHostServer> impleme
      * @param session - An object containing the loop Session information.
      * @param logger - An object containing logging methods.
      */
-    connect(connInfo: ConnInfo.AsObject, session: Session.AsObject, logger: Logger): Promise<void>;
+    connect(connInfo: ConnInfo.AsObject, session: Session.AsObject, logger: ILogger): Promise<void>;
     /**
      * This convenience function returns a promise that resolves once the request has been completed and the response
      * converted to the desired output.
@@ -59,5 +59,5 @@ export default abstract class BaseClient<THost extends CommonHostServer> impleme
     protected set client(client: THost);
     protected get session(): Session.AsObject;
     protected set session(session: Session.AsObject);
-    protected get logger(): Logger;
+    protected get logger(): ILogger;
 }

--- a/ldk/node/dist/hostClients/baseClient.d.ts
+++ b/ldk/node/dist/hostClients/baseClient.d.ts
@@ -26,6 +26,7 @@ export interface SetSessionable {
  */
 export default abstract class BaseClient<THost extends CommonHostServer> implements CommonHostClient {
     private _client;
+    private _logger;
     protected _session: Session.AsObject | undefined;
     /**
      * Implementation should return the constructor function/class for the GRPC Client itself, imported from the SERVICE_grpc_pb file.
@@ -52,9 +53,11 @@ export default abstract class BaseClient<THost extends CommonHostServer> impleme
      */
     buildQuery<TMessage extends SetSessionable, TResponse, TOutput>(clientRequest: (message: TMessage, callback: (err: grpc.ServiceError | null, response: TResponse) => void) => void, builder: () => TMessage, renderer: (response: TResponse) => TOutput | undefined): Promise<TOutput>;
     buildStoppableMessage<TMessage extends SetSessionable, TResponse, TOutput>(clientRequest: (message: TMessage, callback: (err: grpc.ServiceError | null, response: TResponse) => void) => grpc.ClientUnaryCall, builder: () => TMessage, renderer: (response: TResponse) => TOutput): StoppableMessage<TOutput>;
+    protected abstract serviceName(): string;
     protected createSessionMessage(): Session;
     protected get client(): THost;
     protected set client(client: THost);
     protected get session(): Session.AsObject;
     protected set session(session: Session.AsObject);
+    protected get logger(): Logger;
 }

--- a/ldk/node/dist/hostClients/browserClient.d.ts
+++ b/ldk/node/dist/hostClients/browserClient.d.ts
@@ -11,4 +11,5 @@ export declare class BrowserClient extends BaseClient<BrowserGRPCClient> impleme
     streamActiveURL(listener: StreamListener<string>): StoppableStream<string>;
     streamSelectedText(listener: StreamListener<BrowserSelectedTextResponse>): StoppableStream<BrowserSelectedTextResponse>;
     protected generateClient(): GRPCClientConstructor<BrowserGRPCClient>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/browserClient.js
+++ b/ldk/node/dist/hostClients/browserClient.js
@@ -37,5 +37,8 @@ class BrowserClient extends baseClient_1.default {
     generateClient() {
         return browser_grpc_pb_1.BrowserClient;
     }
+    serviceName() {
+        return 'browser';
+    }
 }
 exports.BrowserClient = BrowserClient;

--- a/ldk/node/dist/hostClients/clipboardClient.d.ts
+++ b/ldk/node/dist/hostClients/clipboardClient.d.ts
@@ -10,4 +10,5 @@ export declare class ClipboardClient extends BaseClient<ClipboardGRPCClient> imp
     queryClipboard(): Promise<string>;
     streamClipboard(listener: StreamListener<string>): StoppableStream<string>;
     writeClipboard(text: string): Promise<void>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/clipboardClient.js
+++ b/ldk/node/dist/hostClients/clipboardClient.js
@@ -25,7 +25,9 @@ class ClipboardClient extends baseClient_1.default {
         return this.buildQuery((message, callback) => this.client.clipboardRead(message, callback), () => new clipboard_pb_1.default.ClipboardReadRequest(), clipboardTransformer);
     }
     streamClipboard(listener) {
-        return new transformingStream_1.TransformingStream(this.client.clipboardReadStream(new clipboard_pb_1.default.ClipboardReadStreamRequest().setSession(this.createSessionMessage())), clipboardTransformer, listener);
+        const request = new clipboard_pb_1.default.ClipboardReadStreamRequest().setSession(this.createSessionMessage());
+        this.logger.info('Stream Clipboard Request', 'request', request.getJsPbMessageId() || 'not assigned');
+        return new transformingStream_1.TransformingStream(this.client.clipboardReadStream(request), clipboardTransformer, listener);
     }
     writeClipboard(text) {
         return this.buildQuery((message, callback) => {
@@ -33,6 +35,9 @@ class ClipboardClient extends baseClient_1.default {
         }, () => new clipboard_pb_1.default.ClipboardWriteRequest().setText(text), 
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         () => { });
+    }
+    serviceName() {
+        return 'clipboard';
     }
 }
 exports.ClipboardClient = ClipboardClient;

--- a/ldk/node/dist/hostClients/cursorClient.d.ts
+++ b/ldk/node/dist/hostClients/cursorClient.d.ts
@@ -9,4 +9,5 @@ export declare class CursorClient extends BaseClient<CursorGRPCClient> implement
     protected generateClient(): GRPCClientConstructor<CursorGRPCClient>;
     queryCursorPosition(): Promise<CursorResponse>;
     streamCursorPosition(listener: StreamListener<CursorResponse>): StoppableStream<CursorResponse>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/cursorClient.js
+++ b/ldk/node/dist/hostClients/cursorClient.js
@@ -30,5 +30,8 @@ class CursorClient extends baseClient_1.default {
     streamCursorPosition(listener) {
         return new transformingStream_1.TransformingStream(this.client.cursorPositionStream(new cursor_pb_1.default.CursorPositionStreamRequest().setSession(this.createSessionMessage())), cursorTransformer, listener);
     }
+    serviceName() {
+        return 'cursor';
+    }
 }
 exports.CursorClient = CursorClient;

--- a/ldk/node/dist/hostClients/exceptionLoggingInterceptor.d.ts
+++ b/ldk/node/dist/hostClients/exceptionLoggingInterceptor.d.ts
@@ -1,6 +1,6 @@
 import { Interceptor } from '@grpc/grpc-js';
-import { Logger } from '../logging';
-declare const _default: (logger: Logger) => Interceptor;
+import { ILogger } from '../logging';
+declare const _default: (logger: ILogger) => Interceptor;
 /**
  * Builds an interceptor that logs low-level exceptions
  *

--- a/ldk/node/dist/hostClients/fileSystemClient.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemClient.d.ts
@@ -1,6 +1,6 @@
 import { FilesystemClient as FilesystemGRPCClient } from '../grpc/filesystem_grpc_pb';
 import BaseClient, { GRPCClientConstructor } from './baseClient';
-import { FileSystemService, FileSystemQueryDirectoryParams, FileSystemQueryDirectoryResponse, FileSystemQueryFileParams, FileSystemStreamDirectoryResponse, FileSystemStreamFileInfoResponse } from './fileSystemService';
+import { FileSystemCopyOrMoveParams, FileSystemFile, FileSystemMakeDirectoryParams, FileSystemQueryDirectoryParams, FileSystemQueryDirectoryResponse, FileSystemQueryFileParams, FileSystemRemoveParams, FileSystemService, FileSystemStreamDirectoryResponse, FileSystemStreamFileInfoResponse } from './fileSystemService';
 import { StoppableStream, StreamListener } from './stoppables';
 /**
  * @internal
@@ -10,4 +10,10 @@ export declare class FileSystemClient extends BaseClient<FilesystemGRPCClient> i
     queryDirectory(params: FileSystemQueryDirectoryParams): Promise<FileSystemQueryDirectoryResponse>;
     streamDirectory(params: FileSystemQueryDirectoryParams, listener: StreamListener<FileSystemStreamDirectoryResponse>): StoppableStream<FileSystemStreamDirectoryResponse>;
     streamFileInfo(params: FileSystemQueryFileParams, listener: StreamListener<FileSystemStreamFileInfoResponse>): StoppableStream<FileSystemStreamFileInfoResponse>;
+    copyFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+    moveFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+    makeDirectory(path: FileSystemMakeDirectoryParams): Promise<void>;
+    openFile(path: string): FileSystemFile;
+    createFile(path: string): FileSystemFile;
+    removeFile(params: FileSystemRemoveParams): Promise<void>;
 }

--- a/ldk/node/dist/hostClients/fileSystemClient.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemClient.d.ts
@@ -16,4 +16,5 @@ export declare class FileSystemClient extends BaseClient<FilesystemGRPCClient> i
     openFile(path: string): FileSystemFile;
     createFile(path: string): FileSystemFile;
     removeFile(params: FileSystemRemoveParams): Promise<void>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/fileSystemClient.js
+++ b/ldk/node/dist/hostClients/fileSystemClient.js
@@ -127,12 +127,12 @@ class FileSystemClient extends baseClient_1.default {
         () => { });
     }
     openFile(path) {
-        const impl = new fileSystemFile_1.FileSystemFileImpl(this.session, this.client.filesystemFileStream());
+        const impl = new fileSystemFile_1.FileSystemFileImpl(this.session, this.client.filesystemFileStream(), this.logger);
         impl.open(path);
         return impl;
     }
     createFile(path) {
-        const impl = new fileSystemFile_1.FileSystemFileImpl(this.session, this.client.filesystemFileStream());
+        const impl = new fileSystemFile_1.FileSystemFileImpl(this.session, this.client.filesystemFileStream(), this.logger);
         impl.create(path);
         return impl;
     }
@@ -145,6 +145,9 @@ class FileSystemClient extends baseClient_1.default {
             .setSession(this.createSessionMessage()), 
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         () => { });
+    }
+    serviceName() {
+        return 'filesystem';
     }
 }
 exports.FileSystemClient = FileSystemClient;

--- a/ldk/node/dist/hostClients/fileSystemFile.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemFile.d.ts
@@ -2,7 +2,7 @@ import * as grpc from '@grpc/grpc-js';
 import { FileInfo, FileSystemFile, FileSystemFileChownParams } from './fileSystemService';
 import messages from '../grpc/filesystem_pb';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
+import { ILogger } from '../logging';
 /**
  * @param fileInfo - The file info.
  * @internal
@@ -15,7 +15,7 @@ export declare class FileSystemFileImpl implements FileSystemFile {
     private status;
     private logger;
     private filePath;
-    constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>, logger: Logger);
+    constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>, logger: ILogger);
     open(path: string): void;
     create(path: string): void;
     changeOwnership(params: FileSystemFileChownParams): Promise<void>;

--- a/ldk/node/dist/hostClients/fileSystemFile.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemFile.d.ts
@@ -2,6 +2,7 @@ import * as grpc from '@grpc/grpc-js';
 import { FileInfo, FileSystemFile, FileSystemFileChownParams } from './fileSystemService';
 import messages from '../grpc/filesystem_pb';
 import { Session } from '../grpc/session_pb';
+import { Logger } from '../logging';
 /**
  * @param fileInfo - The file info.
  * @internal
@@ -11,7 +12,8 @@ export declare class FileSystemFileImpl implements FileSystemFile {
     private stream;
     protected session: Session.AsObject;
     private status;
-    constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>);
+    private logger;
+    constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>, logger: Logger);
     open(path: string): void;
     create(path: string): void;
     changeOwnership(params: FileSystemFileChownParams): Promise<void>;

--- a/ldk/node/dist/hostClients/fileSystemFile.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemFile.d.ts
@@ -10,9 +10,11 @@ import { Logger } from '../logging';
 export declare function parseFileInfo(fileInfo: messages.FileInfo): FileInfo;
 export declare class FileSystemFileImpl implements FileSystemFile {
     private stream;
+    streamPromise: Promise<void>;
     protected session: Session.AsObject;
     private status;
     private logger;
+    private filePath;
     constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>, logger: Logger);
     open(path: string): void;
     create(path: string): void;
@@ -24,5 +26,6 @@ export declare class FileSystemFileImpl implements FileSystemFile {
     write(contents: Uint8Array): Promise<number>;
     private generateResponsePromise;
     private checkStatus;
+    private setError;
     protected createSessionMessage(): Session;
 }

--- a/ldk/node/dist/hostClients/fileSystemFile.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemFile.d.ts
@@ -1,0 +1,26 @@
+import * as grpc from '@grpc/grpc-js';
+import { FileInfo, FileSystemFile, FileSystemFileChownParams } from './fileSystemService';
+import messages from '../grpc/filesystem_pb';
+import { Session } from '../grpc/session_pb';
+/**
+ * @param fileInfo - The file info.
+ * @internal
+ */
+export declare function parseFileInfo(fileInfo: messages.FileInfo): FileInfo;
+export declare class FileSystemFileImpl implements FileSystemFile {
+    private stream;
+    protected session: Session.AsObject;
+    private status;
+    constructor(session: Session.AsObject, stream: grpc.ClientDuplexStream<messages.FilesystemFileStreamRequest, messages.FilesystemFileStreamResponse>);
+    open(path: string): void;
+    create(path: string): void;
+    changeOwnership(params: FileSystemFileChownParams): Promise<void>;
+    changePermissions(permissions: number): Promise<void>;
+    close(): Promise<void>;
+    info(): Promise<FileInfo>;
+    read(): Promise<Uint8Array>;
+    write(contents: Uint8Array): Promise<number>;
+    private generateResponsePromise;
+    private checkStatus;
+    protected createSessionMessage(): Session;
+}

--- a/ldk/node/dist/hostClients/fileSystemFile.js
+++ b/ldk/node/dist/hostClients/fileSystemFile.js
@@ -1,0 +1,136 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.FileSystemFileImpl = exports.parseFileInfo = void 0;
+const filesystem_pb_1 = require("../grpc/filesystem_pb");
+const session_pb_1 = require("../grpc/session_pb");
+var FilesystemFileStatus;
+(function (FilesystemFileStatus) {
+    FilesystemFileStatus[FilesystemFileStatus["Pending"] = 0] = "Pending";
+    FilesystemFileStatus[FilesystemFileStatus["Initialized"] = 1] = "Initialized";
+    FilesystemFileStatus[FilesystemFileStatus["Closed"] = 2] = "Closed";
+})(FilesystemFileStatus || (FilesystemFileStatus = {}));
+/**
+ * @param fileInfo - The file info.
+ * @internal
+ */
+function parseFileInfo(fileInfo) {
+    var _a;
+    return {
+        name: fileInfo.getName(),
+        size: fileInfo.getSize(),
+        mode: fileInfo.getMode(),
+        updated: (_a = fileInfo.getUpdated()) === null || _a === void 0 ? void 0 : _a.toDate(),
+        isDir: fileInfo.getIsdir(),
+    };
+}
+exports.parseFileInfo = parseFileInfo;
+class FileSystemFileImpl {
+    constructor(session, stream) {
+        this.status = FilesystemFileStatus.Pending;
+        this.session = session;
+        this.stream = stream;
+    }
+    open(path) {
+        this.checkStatus(true);
+        const openMsg = new filesystem_pb_1.FilesystemFileStreamRequest.Open()
+            .setPath(path)
+            .setSession(this.createSessionMessage());
+        const message = new filesystem_pb_1.FilesystemFileStreamRequest().setOpen(openMsg);
+        this.stream.write(message);
+        this.status = FilesystemFileStatus.Initialized;
+    }
+    create(path) {
+        this.checkStatus(true);
+        const createMsg = new filesystem_pb_1.FilesystemFileStreamRequest.Create()
+            .setPath(path)
+            .setSession(this.createSessionMessage());
+        const message = new filesystem_pb_1.FilesystemFileStreamRequest().setCreate(createMsg);
+        this.stream.write(message);
+        this.status = FilesystemFileStatus.Initialized;
+    }
+    changeOwnership(params) {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Chown()
+            .setUid(params.owner)
+            .setGid(params.group);
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setChown(msg);
+        return this.generateResponsePromise(request, 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (response) => response.getChown(), 
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => { });
+    }
+    changePermissions(permissions) {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Chmod().setMode(permissions);
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setChmod(msg);
+        return this.generateResponsePromise(request, 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (response) => response.getChmod(), 
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => { });
+    }
+    close() {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Close();
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setClose(msg);
+        this.stream.write(request);
+        this.status = FilesystemFileStatus.Closed;
+        return Promise.resolve();
+    }
+    info() {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Stat();
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setStat(msg);
+        return this.generateResponsePromise(request, 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (response) => response.getStat(), 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (input) => parseFileInfo(input.getInfo()));
+    }
+    read() {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Read();
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setRead(msg);
+        return this.generateResponsePromise(request, 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (response) => response.getRead(), (input) => input.getData_asU8());
+    }
+    write(contents) {
+        this.checkStatus();
+        const msg = new filesystem_pb_1.FilesystemFileStreamRequest.Write().setData(contents);
+        const request = new filesystem_pb_1.FilesystemFileStreamRequest().setWrite(msg);
+        return this.generateResponsePromise(request, 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (response) => response.getWrite(), (input) => input.getNumofbytes());
+    }
+    generateResponsePromise(message, responseReader, transformer) {
+        this.stream.write(message);
+        return new Promise((resolve, reject) => {
+            try {
+                const read = this.stream.read();
+                const response = responseReader(read);
+                const transformed = transformer(response);
+                resolve(transformed);
+            }
+            catch (e) {
+                reject();
+            }
+        });
+    }
+    checkStatus(expectPending = false) {
+        if (expectPending && this.status !== FilesystemFileStatus.Pending) {
+            throw new Error('File is not pending');
+        }
+        else if (this.status !== FilesystemFileStatus.Initialized) {
+            throw new Error('File is not open');
+        }
+    }
+    createSessionMessage() {
+        const session = new session_pb_1.Session();
+        session.setLoopid(this.session.loopid);
+        session.setToken(this.session.token);
+        return session;
+    }
+}
+exports.FileSystemFileImpl = FileSystemFileImpl;

--- a/ldk/node/dist/hostClients/fileSystemService.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemService.d.ts
@@ -79,6 +79,12 @@ export interface FileSystemFile {
     info(): Promise<FileInfo>;
     changePermissions(permissions: number): Promise<void>;
     changeOwnership(params: FileSystemFileChownParams): Promise<void>;
+    /**
+     * The streamPromise will resolve when the stream is closed properly, or reject if the stream is closed due to an error.
+     *
+     * Trying to open a file that does not exist will return an error.
+     */
+    streamPromise: Promise<void>;
 }
 /**
  * The FileSystemService provides access to updates made to the file system

--- a/ldk/node/dist/hostClients/fileSystemService.d.ts
+++ b/ldk/node/dist/hostClients/fileSystemService.d.ts
@@ -53,6 +53,33 @@ export interface FileSystemStreamFileInfoResponse {
     file: FileInfo;
     action: FileSystemStreamAction;
 }
+export interface FileSystemCopyOrMoveParams {
+    source: string;
+    destination: string;
+}
+export interface FileSystemRemoveParams {
+    path: string;
+    recursive?: boolean;
+}
+export interface FileSystemMakeDirectoryParams {
+    path: string;
+    permissions: number;
+}
+export interface FileSystemFileChownParams {
+    owner: number;
+    group: number;
+}
+/**
+ * The FileSystemFile interfaces provides access to the ability to write files.
+ */
+export interface FileSystemFile {
+    read(): Promise<Uint8Array>;
+    write(contents: Uint8Array): Promise<number>;
+    close(): Promise<void>;
+    info(): Promise<FileInfo>;
+    changePermissions(permissions: number): Promise<void>;
+    changeOwnership(params: FileSystemFileChownParams): Promise<void>;
+}
 /**
  * The FileSystemService provides access to updates made to the file system
  */
@@ -77,4 +104,46 @@ export interface FileSystemService {
      * @param listener - The listener function called when the file changes.
      */
     streamFileInfo(params: FileSystemQueryFileParams, listener: StreamListener<FileSystemStreamFileInfoResponse>): StoppableStream<FileSystemStreamFileInfoResponse>;
+    /**
+     * Creates a File object to work with.
+     *
+     * @param path - The path of the file to open.
+     */
+    openFile(path: string): FileSystemFile;
+    /**
+     * Creates a file and
+     *
+     * @param path - The path of the file to open.
+     */
+    createFile(path: string): FileSystemFile;
+    /**
+     * Creates a directory.
+     *
+     * @param path - Path of the directory to be created.
+     * @returns Promise resolving when the directory has been created.
+     */
+    makeDirectory(path: FileSystemMakeDirectoryParams): Promise<void>;
+    /**
+     * Copies a file.
+     *
+     * @param params - The parameters for the copy operation.
+     * @returns Promise resolving when the file has been copied.
+     * TODO: Can we copy files only, or directories too?
+     */
+    copyFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+    /**
+     * Moves a file.
+     *
+     * @param params - The parameters for the move operation.
+     * @returns Promise resolving when the file has been moved.
+     * TODO: Can we move files only, or directories too?
+     */
+    moveFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+    /**
+     * Removes a file or directory.
+     *
+     * @param params - The parameters for the move operation.
+     * @returns Promise resolving when the file or directory has been deleted.
+     */
+    removeFile(params: FileSystemRemoveParams): Promise<void>;
 }

--- a/ldk/node/dist/hostClients/hoverClient.d.ts
+++ b/ldk/node/dist/hostClients/hoverClient.d.ts
@@ -9,4 +9,5 @@ export declare class HoverClient extends BaseClient<HoverGRPCClient> implements 
     protected generateClient(): GRPCClientConstructor<HoverGRPCClient>;
     queryHover(params: HoverReadRequest): Promise<HoverResponse>;
     streamHover(params: HoverReadRequest, listener: StreamListener<HoverResponse>): StoppableStream<HoverResponse>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/hoverClient.js
+++ b/ldk/node/dist/hostClients/hoverClient.js
@@ -34,5 +34,8 @@ class HoverClient extends baseClient_1.default {
         const message = updateRequest(params, new hover_pb_1.default.HoverReadStreamRequest().setSession(this.createSessionMessage()));
         return new transformingStream_1.TransformingStream(this.client.hoverReadStream(message), (response) => ({ text: response.getText() }), listener);
     }
+    serviceName() {
+        return 'hover';
+    }
 }
 exports.HoverClient = HoverClient;

--- a/ldk/node/dist/hostClients/keyboardClient.d.ts
+++ b/ldk/node/dist/hostClients/keyboardClient.d.ts
@@ -11,4 +11,5 @@ export default class KeyboardClient extends BaseClient<KeyboardGRPCClient> imple
     streamChar(listener: StreamListener<TextStream>): StoppableStream<TextStream>;
     streamScanCode(listener: StreamListener<ScanCodeEvent>): StoppableStream<ScanCodeEvent>;
     protected generateClient(): GRPCClientConstructor<KeyboardGRPCClient>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/keyboardClient.js
+++ b/ldk/node/dist/hostClients/keyboardClient.js
@@ -80,5 +80,8 @@ class KeyboardClient extends baseClient_1.default {
     generateClient() {
         return keyboard_grpc_pb_1.KeyboardClient;
     }
+    serviceName() {
+        return 'keyboard';
+    }
 }
 exports.default = KeyboardClient;

--- a/ldk/node/dist/hostClients/networkClient.d.ts
+++ b/ldk/node/dist/hostClients/networkClient.d.ts
@@ -4,4 +4,5 @@ import { NetworkService, HttpRequest, HttpResponse } from './networkService';
 export declare class NetworkClient extends BaseClient<NetworkGRPCClient> implements NetworkService {
     protected generateClient(): GRPCClientConstructor<NetworkGRPCClient>;
     httpRequest(req: HttpRequest): Promise<HttpResponse>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/networkClient.js
+++ b/ldk/node/dist/hostClients/networkClient.js
@@ -70,5 +70,8 @@ class NetworkClient extends baseClient_1.default {
             headers: parseHeadersMap(response.getHeadersMap()),
         }));
     }
+    serviceName() {
+        return 'network';
+    }
 }
 exports.NetworkClient = NetworkClient;

--- a/ldk/node/dist/hostClients/processClient.d.ts
+++ b/ldk/node/dist/hostClients/processClient.d.ts
@@ -9,4 +9,5 @@ export declare class ProcessClient extends BaseClient<ProcessGRPCClient> impleme
     protected generateClient(): GRPCClientConstructor<ProcessGRPCClient>;
     queryProcesses(): Promise<ProcessListResponse>;
     streamProcesses(listener: StreamListener<ProcessStreamResponse>): StoppableStream<ProcessStreamResponse>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/processClient.js
+++ b/ldk/node/dist/hostClients/processClient.js
@@ -78,5 +78,8 @@ class ProcessClient extends baseClient_1.default {
             };
         }, listener);
     }
+    serviceName() {
+        return 'process';
+    }
 }
 exports.ProcessClient = ProcessClient;

--- a/ldk/node/dist/hostClients/storageClient.d.ts
+++ b/ldk/node/dist/hostClients/storageClient.d.ts
@@ -36,4 +36,5 @@ export default class StorageClient extends BaseClient<StorageGRPCClient> impleme
      */
     storageWrite(key: string, value: string): Promise<void>;
     protected generateClient(): GRPCClientConstructor<StorageGRPCClient>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/storageClient.js
+++ b/ldk/node/dist/hostClients/storageClient.js
@@ -74,5 +74,8 @@ class StorageClient extends baseClient_1.default {
     generateClient() {
         return storage_grpc_pb_1.StorageClient;
     }
+    serviceName() {
+        return 'storage';
+    }
 }
 exports.default = StorageClient;

--- a/ldk/node/dist/hostClients/uiClient.d.ts
+++ b/ldk/node/dist/hostClients/uiClient.d.ts
@@ -6,4 +6,5 @@ export declare class UIClient extends BaseClient<UIGRPCClient> implements UIServ
     protected generateClient(): GRPCClientConstructor<UIGRPCClient>;
     streamSearchbar(listener: StreamListener<string>): StoppableStream<string>;
     streamGlobalSearch(listener: StreamListener<string>): StoppableStream<string>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/uiClient.js
+++ b/ldk/node/dist/hostClients/uiClient.js
@@ -18,5 +18,8 @@ class UIClient extends baseClient_1.default {
     streamGlobalSearch(listener) {
         return new transformingStream_1.TransformingStream(this.client.globalSearchStream(new ui_pb_1.default.GlobalSearchStreamRequest().setSession(this.createSessionMessage())), (message) => message.getText(), listener);
     }
+    serviceName() {
+        return 'ui';
+    }
 }
 exports.UIClient = UIClient;

--- a/ldk/node/dist/hostClients/whisperClient.d.ts
+++ b/ldk/node/dist/hostClients/whisperClient.d.ts
@@ -21,5 +21,6 @@ declare class WhisperClient extends BaseClient<WhisperGRPCClient> implements Whi
     disambiguationWhisper(whisper: WhisperDisambiguationConfig, listener: StreamListener<WhisperDisambiguationEvent>): StoppableStream<WhisperDisambiguationEvent>;
     formWhisper(whisper: WhisperFormConfig, listener: StreamListener<WhisperFormUpdateEvent | WhisperFormSubmitEvent>): StoppableStream<WhisperFormUpdateEvent | WhisperFormSubmitEvent>;
     protected generateClient(): GRPCClientConstructor<WhisperGRPCClient>;
+    protected serviceName(): string;
 }
 export default WhisperClient;

--- a/ldk/node/dist/hostClients/whisperClient.js
+++ b/ldk/node/dist/hostClients/whisperClient.js
@@ -45,5 +45,8 @@ class WhisperClient extends baseClient_1.default {
     generateClient() {
         return whisper_grpc_pb_1.WhisperClient;
     }
+    serviceName() {
+        return 'whisper';
+    }
 }
 exports.default = WhisperClient;

--- a/ldk/node/dist/hostClients/windowClient.d.ts
+++ b/ldk/node/dist/hostClients/windowClient.d.ts
@@ -11,4 +11,5 @@ export declare class WindowClient extends BaseClient<WindowGRPCClient> implement
     queryWindows(): Promise<WindowInfoResponse[]>;
     streamActiveWindow(listener: StreamListener<WindowInfoResponse>): StoppableStream<WindowInfoResponse>;
     streamWindows(listener: StreamListener<WindowInfoStreamResponse>): StoppableStream<WindowInfoStreamResponse>;
+    protected serviceName(): string;
 }

--- a/ldk/node/dist/hostClients/windowClient.js
+++ b/ldk/node/dist/hostClients/windowClient.js
@@ -81,5 +81,8 @@ class WindowClient extends baseClient_1.default {
             };
         }, listener);
     }
+    serviceName() {
+        return 'window';
+    }
 }
 exports.WindowClient = WindowClient;

--- a/ldk/node/dist/logging.d.ts
+++ b/ldk/node/dist/logging.d.ts
@@ -1,6 +1,17 @@
 /** @module logging */
+/**
+ * Logging interface.
+ */
+export interface ILogger {
+    with(...args: any[]): ILogger;
+    trace(msg: string, ...fields: any[]): void;
+    debug(msg: string, ...fields: any[]): void;
+    info(msg: string, ...fields: any[]): void;
+    warn(msg: string, ...fields: any[]): void;
+    error(msg: string, ...fields: any[]): void;
+}
 /** Logger is a supported way to get logs to Olive Helps in the expected format. */
-declare class Logger {
+export declare class Logger implements ILogger {
     private _name;
     private _fields;
     /**
@@ -161,5 +172,4 @@ declare class Logger {
  *
  * @internal
  */
-declare const prepareLogging: () => void;
-export { Logger, prepareLogging };
+export declare const prepareLogging: () => void;

--- a/ldk/node/dist/logging.js
+++ b/ldk/node/dist/logging.js
@@ -2,6 +2,7 @@
 /** @module logging */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.prepareLogging = exports.Logger = void 0;
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @internal
  */
@@ -60,7 +61,6 @@ class Logger {
      * // }
      * ```
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     with(...args) {
         const fields = this._kvArgsWithFields(args);
         return new Logger(this._name, fields);
@@ -238,14 +238,13 @@ exports.Logger = Logger;
  *
  * @internal
  */
-const prepareLogging = () => {
+exports.prepareLogging = () => {
     const consoleDebug = console.debug.bind(console);
     const consoleError = console.error.bind(console);
     const consoleInfo = console.info.bind(console);
     const consoleLog = console.log.bind(console);
     const consoleTrace = console.trace.bind(console);
     const consoleWarn = console.warn.bind(console);
-    /* eslint-disable @typescript-eslint/no-explicit-any */
     // Using any b/c console functions accept any type.
     console.debug = (msg, ...args) => {
         consoleDebug(`[DEBUG] ${msg}`, ...args);
@@ -266,6 +265,5 @@ const prepareLogging = () => {
         consoleWarn(`[WARN] ${msg}`, ...args);
     };
     process.stdout.write = (...args) => process.stderr.write(...args);
-    /* eslint-any @typescript-eslint/no-explicit-any */
 };
-exports.prepareLogging = prepareLogging;
+/* eslint-any @typescript-eslint/no-explicit-any */

--- a/ldk/node/dist/testLogger.d.ts
+++ b/ldk/node/dist/testLogger.d.ts
@@ -1,0 +1,14 @@
+import { ILogger } from './logging';
+/**
+ * This ILogger implementation swallows logging statements.
+ *
+ * @internal
+ */
+export declare class TestLogger implements ILogger {
+    debug(): void;
+    error(): void;
+    info(): void;
+    trace(): void;
+    warn(): void;
+    with(): ILogger;
+}

--- a/ldk/node/dist/testLogger.js
+++ b/ldk/node/dist/testLogger.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TestLogger = void 0;
+/**
+ * This ILogger implementation swallows logging statements.
+ *
+ * @internal
+ */
+class TestLogger {
+    debug() { }
+    error() { }
+    info() { }
+    trace() { }
+    warn() { }
+    with() {
+        return this;
+    }
+}
+exports.TestLogger = TestLogger;

--- a/ldk/node/examples/clipboard/src/index.ts
+++ b/ldk/node/examples/clipboard/src/index.ts
@@ -35,6 +35,9 @@ class ClipboardLoop implements Loop {
       label: 'File Info',
       markdown: JSON.stringify(fileInfo),
     });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5000);
+    });
     await file.close();
     logger.debug('File Closed');
   }

--- a/ldk/node/examples/clipboard/src/index.ts
+++ b/ldk/node/examples/clipboard/src/index.ts
@@ -12,22 +12,31 @@ class ClipboardLoop implements Loop {
     this._host = host;
     logger.info('Requesting Stream');
     try {
-      this.host.clipboard.streamClipboard((error, response) => {
-        logger.info(
-          'Received Clipboard Event',
-          'response',
-          JSON.stringify(response),
-        );
-        if (response) {
-          this.host.whisper.markdownWhisper({
-            markdown: `Clipboard Node Text: ${response}`,
-            label: 'Clipboard Node Event',
-          });
+      this.host.clipboard.streamClipboard(async (error, response) => {
+        if (response !== 'fileinfo') {
+          return;
         }
+        this.workFile().catch((e) => {
+          logger.error('Received Error', 'error', e);
+        });
       });
     } catch (e) {
       logger.error('Error Streaming', 'error', e.toString());
     }
+  }
+
+  async workFile(): Promise<void> {
+    logger.debug('Opening File');
+    const file = this.host.fileSystem.openFile('/tmp/log.txt');
+    logger.debug('Getting File');
+    const fileInfo = await file.info();
+    logger.debug('Received File', 'info', JSON.stringify(fileInfo));
+    this.host.whisper.markdownWhisper({
+      label: 'File Info',
+      markdown: JSON.stringify(fileInfo),
+    });
+    await file.close();
+    logger.debug('File Closed');
   }
 
   stop(): void {

--- a/ldk/node/readme.md
+++ b/ldk/node/readme.md
@@ -158,3 +158,5 @@ The `.proto` files in `src/shared/proto` are inserted with Git subtrees. To upda
 ### Testing
 
 Tests are written with [`ts-jest`](https://kulshekhar.github.io/ts-jest/).
+
+Set `TEST_LOGGING` environment variable to a non-empty value to get Logger output when running tests.

--- a/ldk/node/src/hostClients/baseClient.test.ts
+++ b/ldk/node/src/hostClients/baseClient.test.ts
@@ -8,10 +8,10 @@ import {
   createCallbackHandler,
   defaultConnInfo,
   defaultSession,
+  buildLogger,
 } from '../test.helpers';
-import { Logger } from '../logging';
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('BaseClient', () => {
   let subject: BaseClient<FakeGRPCClient>;

--- a/ldk/node/src/hostClients/baseClient.ts
+++ b/ldk/node/src/hostClients/baseClient.ts
@@ -5,7 +5,7 @@ import { CommonHostClient } from './commonHostClient';
 import { Session } from '../grpc/session_pb';
 import { StoppableMessage } from './stoppables';
 import { TransformingMessage } from './transformingMessage';
-import { Logger } from '../logging';
+import { ILogger } from '../logging';
 import buildLoggingInterceptor from './exceptionLoggingInterceptor';
 
 /**
@@ -38,7 +38,7 @@ export default abstract class BaseClient<THost extends CommonHostServer>
   implements CommonHostClient {
   private _client: THost | undefined;
 
-  private _logger: Logger | undefined;
+  private _logger: ILogger | undefined;
 
   protected _session: Session.AsObject | undefined;
 
@@ -60,7 +60,7 @@ export default abstract class BaseClient<THost extends CommonHostServer>
   connect(
     connInfo: ConnInfo.AsObject,
     session: Session.AsObject,
-    logger: Logger,
+    logger: ILogger,
   ): Promise<void> {
     this._logger = logger.with('service', this.serviceName());
     return new Promise((resolve, reject) => {
@@ -179,7 +179,7 @@ export default abstract class BaseClient<THost extends CommonHostServer>
     this._session = session;
   }
 
-  protected get logger(): Logger {
+  protected get logger(): ILogger {
     if (this._logger == null) {
       throw new Error('Accessing Logger before Connection');
     }

--- a/ldk/node/src/hostClients/baseClient.ts
+++ b/ldk/node/src/hostClients/baseClient.ts
@@ -38,6 +38,8 @@ export default abstract class BaseClient<THost extends CommonHostServer>
   implements CommonHostClient {
   private _client: THost | undefined;
 
+  private _logger: Logger | undefined;
+
   protected _session: Session.AsObject | undefined;
 
   /**
@@ -60,6 +62,7 @@ export default abstract class BaseClient<THost extends CommonHostServer>
     session: Session.AsObject,
     logger: Logger,
   ): Promise<void> {
+    this._logger = logger.with('service', this.serviceName());
     return new Promise((resolve, reject) => {
       let address: string;
       if (connInfo.network === 'unix') {
@@ -86,9 +89,10 @@ export default abstract class BaseClient<THost extends CommonHostServer>
 
       this.client.waitForReady(deadline, (err) => {
         if (err) {
-          logger.error('Connection Failed', 'address', address);
+          logger.error('Client Connection Failed', 'address', address);
           return reject(err);
         }
+        this.logger.trace('Client Connected');
         return resolve();
       });
     });
@@ -112,12 +116,17 @@ export default abstract class BaseClient<THost extends CommonHostServer>
   ): Promise<TOutput> {
     return new Promise((resolve, reject) => {
       const message = builder();
+      this.logger.trace('buildQuery - Starting Message');
       message.setSession(this.createSessionMessage());
       const callback = (err: grpc.ServiceError | null, response: TResponse) => {
         if (err) {
+          this.logger.trace('buildQuery - Received Error');
           return reject(err);
         }
-        return resolve(renderer(response));
+        this.logger.trace('buildQuery - Received Response');
+        const renderer1 = renderer(response);
+        this.logger.trace('buildQuery - Parsed Response, Returning');
+        return resolve(renderer1);
       };
       clientRequest(message, callback);
     });
@@ -138,6 +147,8 @@ export default abstract class BaseClient<THost extends CommonHostServer>
     result.assignCall(call);
     return result;
   }
+
+  protected abstract serviceName(): string;
 
   protected createSessionMessage(): Session {
     const session = new Session();
@@ -166,5 +177,12 @@ export default abstract class BaseClient<THost extends CommonHostServer>
 
   protected set session(session: Session.AsObject) {
     this._session = session;
+  }
+
+  protected get logger(): Logger {
+    if (this._logger == null) {
+      throw new Error('Accessing Logger before Connection');
+    }
+    return this._logger;
   }
 }

--- a/ldk/node/src/hostClients/browserClient.test.ts
+++ b/ldk/node/src/hostClients/browserClient.test.ts
@@ -7,6 +7,7 @@ import { BrowserClient } from './browserClient';
 import { Session } from '../grpc/session_pb';
 import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -21,7 +22,7 @@ jest.mock('../grpc/browser_grpc_pb');
 
 const MockClientClass = mocked(Services.BrowserClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('BrowserClient', () => {
   let subject: BrowserClient;

--- a/ldk/node/src/hostClients/browserClient.ts
+++ b/ldk/node/src/hostClients/browserClient.ts
@@ -85,4 +85,8 @@ export class BrowserClient
   protected generateClient(): GRPCClientConstructor<BrowserGRPCClient> {
     return BrowserGRPCClient;
   }
+
+  protected serviceName(): string {
+    return 'browser';
+  }
 }

--- a/ldk/node/src/hostClients/clipboardClient.test.ts
+++ b/ldk/node/src/hostClients/clipboardClient.test.ts
@@ -7,6 +7,7 @@ import { ClipboardClient } from './clipboardClient';
 import { Session } from '../grpc/session_pb';
 import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -20,7 +21,7 @@ jest.mock('../grpc/clipboard_grpc_pb');
 
 const MockClientClass = mocked(Services.ClipboardClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('ClipboardClient', () => {
   let subject: ClipboardClient;

--- a/ldk/node/src/hostClients/clipboardClient.ts
+++ b/ldk/node/src/hostClients/clipboardClient.ts
@@ -39,12 +39,16 @@ export class ClipboardClient
   }
 
   streamClipboard(listener: StreamListener<string>): StoppableStream<string> {
+    const request = new messages.ClipboardReadStreamRequest().setSession(
+      this.createSessionMessage(),
+    );
+    this.logger.info(
+      'Stream Clipboard Request',
+      'request',
+      request.getJsPbMessageId() || 'not assigned',
+    );
     return new TransformingStream<messages.ClipboardReadStreamResponse, string>(
-      this.client.clipboardReadStream(
-        new messages.ClipboardReadStreamRequest().setSession(
-          this.createSessionMessage(),
-        ),
-      ),
+      this.client.clipboardReadStream(request),
       clipboardTransformer,
       listener,
     );
@@ -59,5 +63,9 @@ export class ClipboardClient
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       () => {},
     );
+  }
+
+  protected serviceName(): string {
+    return 'clipboard';
   }
 }

--- a/ldk/node/src/hostClients/cursorClient.test.ts
+++ b/ldk/node/src/hostClients/cursorClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/cursor_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { CursorClient } from './cursorClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -21,7 +21,7 @@ jest.mock('../grpc/cursor_grpc_pb');
 
 const MockClientClass = mocked(Services.CursorClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('CursorClient', () => {
   let subject: CursorClient;

--- a/ldk/node/src/hostClients/cursorClient.ts
+++ b/ldk/node/src/hostClients/cursorClient.ts
@@ -56,4 +56,8 @@ export class CursorClient
       listener,
     );
   }
+
+  protected serviceName(): string {
+    return 'cursor';
+  }
 }

--- a/ldk/node/src/hostClients/exceptionLoggingInterceptor.ts
+++ b/ldk/node/src/hostClients/exceptionLoggingInterceptor.ts
@@ -7,7 +7,7 @@ import {
 } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
 import { NextCall } from '@grpc/grpc-js/build/src/client-interceptors';
-import { Logger } from '../logging';
+import { ILogger, Logger } from '../logging';
 
 const METHOD_PATH = /^\/proto\.(?<service>\w+)\/(?<method>\w+)$/;
 /**
@@ -28,7 +28,7 @@ function extractContext(options: InterceptorOptions) {
  *
  * @param logger - the logger to use for logging exceptions
  */
-export default (logger: Logger): Interceptor => (
+export default (logger: ILogger): Interceptor => (
   options: InterceptorOptions,
   nextCall: NextCall,
 ) => {

--- a/ldk/node/src/hostClients/fileSystemClient.test.ts
+++ b/ldk/node/src/hostClients/fileSystemClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/filesystem_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { FileSystemClient } from './fileSystemClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -21,7 +21,7 @@ jest.mock('../grpc/filesystem_grpc_pb');
 
 const MockClientClass = mocked(Services.FilesystemClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('FileSystemClient', () => {
   let subject: FileSystemClient;

--- a/ldk/node/src/hostClients/fileSystemClient.ts
+++ b/ldk/node/src/hostClients/fileSystemClient.ts
@@ -170,6 +170,7 @@ export class FileSystemClient
     const impl = new FileSystemFileImpl(
       this.session,
       this.client.filesystemFileStream(),
+      this.logger,
     );
     impl.open(path);
     return impl;
@@ -179,6 +180,7 @@ export class FileSystemClient
     const impl = new FileSystemFileImpl(
       this.session,
       this.client.filesystemFileStream(),
+      this.logger,
     );
     impl.create(path);
     return impl;
@@ -197,5 +199,9 @@ export class FileSystemClient
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       () => {},
     );
+  }
+
+  protected serviceName(): string {
+    return 'filesystem';
   }
 }

--- a/ldk/node/src/hostClients/fileSystemFile.ts
+++ b/ldk/node/src/hostClients/fileSystemFile.ts
@@ -1,0 +1,179 @@
+import * as grpc from '@grpc/grpc-js';
+import {
+  FileInfo,
+  FileSystemFile,
+  FileSystemFileChownParams,
+} from './fileSystemService';
+import messages, { FilesystemFileStreamRequest } from '../grpc/filesystem_pb';
+import { Session } from '../grpc/session_pb';
+
+enum FilesystemFileStatus {
+  Pending,
+  Initialized,
+  Closed,
+}
+
+/**
+ * @param fileInfo - The file info.
+ * @internal
+ */
+export function parseFileInfo(fileInfo: messages.FileInfo): FileInfo {
+  return {
+    name: fileInfo.getName(),
+    size: fileInfo.getSize(),
+    mode: fileInfo.getMode(),
+    updated: fileInfo.getUpdated()?.toDate(),
+    isDir: fileInfo.getIsdir(),
+  };
+}
+
+export class FileSystemFileImpl implements FileSystemFile {
+  private stream: grpc.ClientDuplexStream<
+    messages.FilesystemFileStreamRequest,
+    messages.FilesystemFileStreamResponse
+  >;
+
+  protected session: Session.AsObject;
+
+  private status: FilesystemFileStatus = FilesystemFileStatus.Pending;
+
+  constructor(
+    session: Session.AsObject,
+    stream: grpc.ClientDuplexStream<
+      messages.FilesystemFileStreamRequest,
+      messages.FilesystemFileStreamResponse
+    >,
+  ) {
+    this.session = session;
+    this.stream = stream;
+  }
+
+  open(path: string): void {
+    this.checkStatus(true);
+    const openMsg = new FilesystemFileStreamRequest.Open()
+      .setPath(path)
+      .setSession(this.createSessionMessage());
+    const message = new FilesystemFileStreamRequest().setOpen(openMsg);
+    this.stream.write(message);
+    this.status = FilesystemFileStatus.Initialized;
+  }
+
+  create(path: string): void {
+    this.checkStatus(true);
+    const createMsg = new FilesystemFileStreamRequest.Create()
+      .setPath(path)
+      .setSession(this.createSessionMessage());
+    const message = new FilesystemFileStreamRequest().setCreate(createMsg);
+    this.stream.write(message);
+    this.status = FilesystemFileStatus.Initialized;
+  }
+
+  changeOwnership(params: FileSystemFileChownParams): Promise<void> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Chown()
+      .setUid(params.owner)
+      .setGid(params.group);
+    const request = new FilesystemFileStreamRequest().setChown(msg);
+    return this.generateResponsePromise(
+      request,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (response) => response.getChown()!,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
+    );
+  }
+
+  changePermissions(permissions: number): Promise<void> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Chmod().setMode(permissions);
+    const request = new FilesystemFileStreamRequest().setChmod(msg);
+    return this.generateResponsePromise(
+      request,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (response) => response.getChmod()!,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
+    );
+  }
+
+  close(): Promise<void> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Close();
+    const request = new FilesystemFileStreamRequest().setClose(msg);
+    this.stream.write(request);
+    this.status = FilesystemFileStatus.Closed;
+    return Promise.resolve();
+  }
+
+  info(): Promise<FileInfo> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Stat();
+    const request = new FilesystemFileStreamRequest().setStat(msg);
+    return this.generateResponsePromise(
+      request,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (response) => response.getStat()!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (input) => parseFileInfo(input.getInfo()!),
+    );
+  }
+
+  read(): Promise<Uint8Array> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Read();
+    const request = new FilesystemFileStreamRequest().setRead(msg);
+    return this.generateResponsePromise(
+      request,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (response) => response.getRead()!,
+      (input) => input.getData_asU8(),
+    );
+  }
+
+  write(contents: Uint8Array): Promise<number> {
+    this.checkStatus();
+    const msg = new FilesystemFileStreamRequest.Write().setData(contents);
+    const request = new FilesystemFileStreamRequest().setWrite(msg);
+    return this.generateResponsePromise(
+      request,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (response) => response.getWrite()!,
+      (input) => input.getNumofbytes(),
+    );
+  }
+
+  private generateResponsePromise<TResponse, TOutput>(
+    message: messages.FilesystemFileStreamRequest,
+    responseReader: (
+      response: messages.FilesystemFileStreamResponse,
+    ) => TResponse,
+    transformer: (input: TResponse) => TOutput,
+  ): Promise<TOutput> {
+    this.stream.write(message);
+    return new Promise<TOutput>((resolve, reject) => {
+      try {
+        const read = this.stream.read();
+        const response = responseReader(read);
+        const transformed = transformer(response);
+        resolve(transformed);
+      } catch (e) {
+        reject();
+      }
+    });
+  }
+
+  private checkStatus(expectPending = false): void {
+    if (expectPending && this.status !== FilesystemFileStatus.Pending) {
+      throw new Error('File is not pending');
+    } else if (this.status !== FilesystemFileStatus.Initialized) {
+      throw new Error('File is not open');
+    }
+  }
+
+  protected createSessionMessage(): Session {
+    const session = new Session();
+    session.setLoopid(this.session.loopid);
+    session.setToken(this.session.token);
+    return session;
+  }
+}

--- a/ldk/node/src/hostClients/fileSystemFile.ts
+++ b/ldk/node/src/hostClients/fileSystemFile.ts
@@ -6,7 +6,7 @@ import {
 } from './fileSystemService';
 import messages, { FilesystemFileStreamRequest } from '../grpc/filesystem_pb';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
+import { ILogger } from '../logging';
 
 enum FilesystemFileStatus {
   Pending,
@@ -41,7 +41,7 @@ export class FileSystemFileImpl implements FileSystemFile {
 
   private status: FilesystemFileStatus = FilesystemFileStatus.Pending;
 
-  private logger: Logger;
+  private logger: ILogger;
 
   private filePath: string | undefined;
 
@@ -51,7 +51,7 @@ export class FileSystemFileImpl implements FileSystemFile {
       messages.FilesystemFileStreamRequest,
       messages.FilesystemFileStreamResponse
     >,
-    logger: Logger,
+    logger: ILogger,
   ) {
     this.logger = logger.with('service', 'filesystem.file');
     this.session = session;

--- a/ldk/node/src/hostClients/fileSystemService.ts
+++ b/ldk/node/src/hostClients/fileSystemService.ts
@@ -62,6 +62,38 @@ export interface FileSystemStreamFileInfoResponse {
   action: FileSystemStreamAction;
 }
 
+export interface FileSystemCopyOrMoveParams {
+  source: string;
+  destination: string;
+}
+
+export interface FileSystemRemoveParams {
+  path: string;
+  recursive?: boolean;
+}
+
+export interface FileSystemMakeDirectoryParams {
+  path: string;
+  permissions: number;
+}
+
+export interface FileSystemFileChownParams {
+  owner: number;
+  group: number;
+}
+
+/**
+ * The FileSystemFile interfaces provides access to the ability to write files.
+ */
+export interface FileSystemFile {
+  read(): Promise<Uint8Array>;
+  write(contents: Uint8Array): Promise<number>;
+  close(): Promise<void>;
+  info(): Promise<FileInfo>;
+  changePermissions(permissions: number): Promise<void>;
+  changeOwnership(params: FileSystemFileChownParams): Promise<void>;
+}
+
 /**
  * The FileSystemService provides access to updates made to the file system
  */
@@ -96,4 +128,52 @@ export interface FileSystemService {
     params: FileSystemQueryFileParams,
     listener: StreamListener<FileSystemStreamFileInfoResponse>,
   ): StoppableStream<FileSystemStreamFileInfoResponse>;
+
+  /**
+   * Creates a File object to work with.
+   *
+   * @param path - The path of the file to open.
+   */
+  openFile(path: string): FileSystemFile;
+
+  /**
+   * Creates a file and
+   *
+   * @param path - The path of the file to open.
+   */
+  createFile(path: string): FileSystemFile;
+
+  /**
+   * Creates a directory.
+   *
+   * @param path - Path of the directory to be created.
+   * @returns Promise resolving when the directory has been created.
+   */
+  makeDirectory(path: FileSystemMakeDirectoryParams): Promise<void>;
+
+  /**
+   * Copies a file.
+   *
+   * @param params - The parameters for the copy operation.
+   * @returns Promise resolving when the file has been copied.
+   * TODO: Can we copy files only, or directories too?
+   */
+  copyFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+
+  /**
+   * Moves a file.
+   *
+   * @param params - The parameters for the move operation.
+   * @returns Promise resolving when the file has been moved.
+   * TODO: Can we move files only, or directories too?
+   */
+  moveFile(params: FileSystemCopyOrMoveParams): Promise<void>;
+
+  /**
+   * Removes a file or directory.
+   *
+   * @param params - The parameters for the move operation.
+   * @returns Promise resolving when the file or directory has been deleted.
+   */
+  removeFile(params: FileSystemRemoveParams): Promise<void>;
 }

--- a/ldk/node/src/hostClients/fileSystemService.ts
+++ b/ldk/node/src/hostClients/fileSystemService.ts
@@ -92,6 +92,13 @@ export interface FileSystemFile {
   info(): Promise<FileInfo>;
   changePermissions(permissions: number): Promise<void>;
   changeOwnership(params: FileSystemFileChownParams): Promise<void>;
+
+  /**
+   * The streamPromise will resolve when the stream is closed properly, or reject if the stream is closed due to an error.
+   *
+   * Trying to open a file that does not exist will return an error.
+   */
+  streamPromise: Promise<void>;
 }
 
 /**

--- a/ldk/node/src/hostClients/hoverClient.test.ts
+++ b/ldk/node/src/hostClients/hoverClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/hover_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { HoverClient } from './hoverClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -21,7 +21,7 @@ jest.mock('../grpc/hover_grpc_pb');
 
 const MockClientClass = mocked(Services.HoverClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('HoverClient', () => {
   let subject: HoverClient;

--- a/ldk/node/src/hostClients/hoverClient.ts
+++ b/ldk/node/src/hostClients/hoverClient.ts
@@ -58,4 +58,8 @@ export class HoverClient
       listener,
     );
   }
+
+  protected serviceName(): string {
+    return 'hover';
+  }
 }

--- a/ldk/node/src/hostClients/keyboardClient.test.ts
+++ b/ldk/node/src/hostClients/keyboardClient.test.ts
@@ -6,8 +6,8 @@ import * as Messages from '../grpc/keyboard_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import KeyboardClient from './keyboardClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createEmptyStream,
   createStreamingHandler,
@@ -22,7 +22,7 @@ jest.mock('../grpc/keyboard_grpc_pb');
 
 const MockClientClass = mocked(Services.KeyboardClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('KeyboardClient', () => {
   let subject: KeyboardClient;

--- a/ldk/node/src/hostClients/keyboardClient.ts
+++ b/ldk/node/src/hostClients/keyboardClient.ts
@@ -144,4 +144,8 @@ export default class KeyboardClient
   protected generateClient(): GRPCClientConstructor<KeyboardGRPCClient> {
     return KeyboardGRPCClient;
   }
+
+  protected serviceName(): string {
+    return 'keyboard';
+  }
 }

--- a/ldk/node/src/hostClients/networkClient.test.ts
+++ b/ldk/node/src/hostClients/networkClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/network_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { NetworkClient } from './networkClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createWaitHandler,
@@ -20,7 +20,7 @@ jest.mock('../grpc/network_grpc_pb');
 
 const MockClientClass = mocked(Services.NetworkClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('NetworkClient', () => {
   let subject: NetworkClient;

--- a/ldk/node/src/hostClients/networkClient.ts
+++ b/ldk/node/src/hostClients/networkClient.ts
@@ -69,4 +69,8 @@ export class NetworkClient
       }),
     );
   }
+
+  protected serviceName(): string {
+    return 'network';
+  }
 }

--- a/ldk/node/src/hostClients/processClient.test.ts
+++ b/ldk/node/src/hostClients/processClient.test.ts
@@ -6,8 +6,8 @@ import * as Messages from '../grpc/process_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { ProcessClient } from './processClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createEmptyStream,
@@ -23,7 +23,7 @@ jest.mock('../grpc/process_grpc_pb');
 
 const MockClientClass = mocked(Services.ProcessClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('ProcessClient', () => {
   let subject: ProcessClient;

--- a/ldk/node/src/hostClients/processClient.ts
+++ b/ldk/node/src/hostClients/processClient.ts
@@ -90,4 +90,8 @@ export class ProcessClient
       listener,
     );
   }
+
+  protected serviceName(): string {
+    return 'process';
+  }
 }

--- a/ldk/node/src/hostClients/storageClient.test.ts
+++ b/ldk/node/src/hostClients/storageClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/storage_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import StorageClient from './storageClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createWaitHandler,
@@ -18,7 +18,7 @@ jest.mock('../grpc/storage_grpc_pb');
 
 const MockClientClass = mocked(Services.StorageClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('StorageHostClient', () => {
   let subject: StorageClient;

--- a/ldk/node/src/hostClients/storageClient.ts
+++ b/ldk/node/src/hostClients/storageClient.ts
@@ -99,4 +99,8 @@ export default class StorageClient
   protected generateClient(): GRPCClientConstructor<StorageGRPCClient> {
     return StorageGRPCClient;
   }
+
+  protected serviceName(): string {
+    return 'storage';
+  }
 }

--- a/ldk/node/src/hostClients/uiClient.test.ts
+++ b/ldk/node/src/hostClients/uiClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/ui_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { UIClient } from './uiClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createStreamingHandler,
   createWaitHandler,
@@ -19,7 +19,7 @@ jest.mock('../grpc/ui_grpc_pb');
 
 const MockClientClass = mocked(Services.UIClient);
 
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('UIClient', () => {
   let subject: UIClient;

--- a/ldk/node/src/hostClients/uiClient.ts
+++ b/ldk/node/src/hostClients/uiClient.ts
@@ -35,4 +35,8 @@ export class UIClient extends BaseClient<UIGRPCClient> implements UIService {
       listener,
     );
   }
+
+  protected serviceName(): string {
+    return 'ui';
+  }
 }

--- a/ldk/node/src/hostClients/whisperClient.test.ts
+++ b/ldk/node/src/hostClients/whisperClient.test.ts
@@ -5,8 +5,8 @@ import WhisperClient from './whisperClient';
 import { ConnInfo } from '../grpc/broker_pb';
 import { Session } from '../grpc/session_pb';
 import * as Builders from './whisperMessageBuilder';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   createCallbackHandler,
   createWaitHandler,
   defaultConnInfo,
@@ -19,7 +19,7 @@ jest.mock('./whisperMessageBuilder');
 const WHISPER_ID = '1234-abcd';
 const MockClientClass = mocked(Services.WhisperClient);
 const messageBuilders = mocked(Builders);
-const testLogger = new Logger('test-logger');
+const testLogger = buildLogger();
 
 describe('WhisperHostClient', () => {
   let subject: WhisperClient;

--- a/ldk/node/src/hostClients/whisperClient.ts
+++ b/ldk/node/src/hostClients/whisperClient.ts
@@ -117,6 +117,10 @@ class WhisperClient
   protected generateClient(): GRPCClientConstructor<WhisperGRPCClient> {
     return WhisperGRPCClient;
   }
+
+  protected serviceName(): string {
+    return 'whisper';
+  }
 }
 
 export default WhisperClient;

--- a/ldk/node/src/hostClients/windowClient.test.ts
+++ b/ldk/node/src/hostClients/windowClient.test.ts
@@ -5,8 +5,8 @@ import * as Messages from '../grpc/window_pb';
 import { ConnInfo } from '../grpc/broker_pb';
 import { WindowClient } from './windowClient';
 import { Session } from '../grpc/session_pb';
-import { Logger } from '../logging';
 import {
+  buildLogger,
   captureMockArgument,
   createCallbackHandler,
   createStreamingHandler,
@@ -20,7 +20,7 @@ import { WindowInfoResponse } from './windowService';
 jest.mock('../grpc/window_grpc_pb');
 
 const MockClientClass = mocked(Services.WindowClient);
-const logger = new Logger('test-logger');
+const logger = buildLogger();
 
 describe('WindowClient', () => {
   let subject: WindowClient;

--- a/ldk/node/src/hostClients/windowClient.ts
+++ b/ldk/node/src/hostClients/windowClient.ts
@@ -112,4 +112,8 @@ export class WindowClient
       listener,
     );
   }
+
+  protected serviceName(): string {
+    return 'window';
+  }
 }

--- a/ldk/node/src/logging.ts
+++ b/ldk/node/src/logging.ts
@@ -1,5 +1,7 @@
 /** @module logging */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * @internal
  */
@@ -18,11 +20,22 @@ enum LogLevels {
   ERROR = 'ERROR',
 }
 
+/**
+ * Logging interface.
+ */
+export interface ILogger {
+  with(...args: any[]): ILogger;
+  trace(msg: string, ...fields: any[]): void;
+  debug(msg: string, ...fields: any[]): void;
+  info(msg: string, ...fields: any[]): void;
+  warn(msg: string, ...fields: any[]): void;
+  error(msg: string, ...fields: any[]): void;
+}
+
 /** Logger is a supported way to get logs to Olive Helps in the expected format. */
-class Logger {
+export class Logger implements ILogger {
   private _name: string;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _fields: { [index: string]: any };
 
   /**
@@ -66,7 +79,6 @@ class Logger {
    * // }
    * ```
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   with(...args: any[]): Logger {
     const fields = this._kvArgsWithFields(args);
     return new Logger(this._name, fields);
@@ -275,7 +287,7 @@ class Logger {
  *
  * @internal
  */
-const prepareLogging = (): void => {
+export const prepareLogging = (): void => {
   const consoleDebug = console.debug.bind(console);
   const consoleError = console.error.bind(console);
   const consoleInfo = console.info.bind(console);
@@ -283,7 +295,6 @@ const prepareLogging = (): void => {
   const consoleTrace = console.trace.bind(console);
   const consoleWarn = console.warn.bind(console);
 
-  /* eslint-disable @typescript-eslint/no-explicit-any */
   // Using any b/c console functions accept any type.
   console.debug = (msg: any, ...args: any[]) => {
     consoleDebug(`[DEBUG] ${msg}`, ...args);
@@ -311,7 +322,5 @@ const prepareLogging = (): void => {
 
   process.stdout.write = (...args: any[]) =>
     (process.stderr.write as any)(...args);
-  /* eslint-any @typescript-eslint/no-explicit-any */
 };
-
-export { Logger, prepareLogging };
+/* eslint-any @typescript-eslint/no-explicit-any */

--- a/ldk/node/src/test.helpers.ts
+++ b/ldk/node/src/test.helpers.ts
@@ -9,6 +9,18 @@ import { Deadline } from '@grpc/grpc-js';
 import { ConnInfo } from './grpc/broker_pb';
 import { Session } from './grpc/session_pb';
 import BaseClient, { GRPCClientConstructor } from './hostClients/baseClient';
+import { ILogger, Logger } from './logging';
+import { TestLogger } from './testLogger';
+
+/**
+ * @internal
+ */
+export function buildLogger(): ILogger {
+  if (process.env.TEST_LOGGING != null) {
+    return new Logger('test-logger');
+  }
+  return new TestLogger();
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export type CallbackFunc<TResponse = any> = (
@@ -131,6 +143,10 @@ export class FakeGRPCClient {
 export class FakeHostServer extends BaseClient<FakeGRPCClient> {
   protected generateClient(): GRPCClientConstructor<FakeGRPCClient> {
     return FakeGRPCClient;
+  }
+
+  protected serviceName(): string {
+    return '';
   }
 }
 

--- a/ldk/node/src/testLogger.ts
+++ b/ldk/node/src/testLogger.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-empty-function, @typescript-eslint/no-explicit-any */
+import { ILogger } from './logging';
+
+/**
+ * This ILogger implementation swallows logging statements.
+ *
+ * @internal
+ */
+export class TestLogger implements ILogger {
+  debug(): void {}
+
+  error(): void {}
+
+  info(): void {}
+
+  trace(): void {}
+
+  warn(): void {}
+
+  with(): ILogger {
+    return this;
+  }
+}


### PR DESCRIPTION
This PR:

- Implements the Filesystem sensors changes (File stream + copy/move, remove, makeDir).
- Adds a framework for bidirectional stream implementation. These are currently in the File classes and can be extracted when another bidirectional stream is implemented.
- Adds improved logging to the Node and .Net clients. 