### PR TITLE
[SIDE-1508] Unblock Close without waiting for stream to close

### DIFF
--- a/ldk/go/filesystemClient.go
+++ b/ldk/go/filesystemClient.go
@@ -289,14 +289,10 @@ func (f *GRPCFile) Close() error {
 		},
 	})
 	if err != nil {
+		println("[ERROR] GRPCFile.Close - Received error sending Close", err.Error())
 		return err
 	}
-	select {
-	case <-f.ctx.Done():
-		return nil
-	case <-f.stream.Context().Done():
-		return nil
-	}
+	return nil
 }
 
 // Chown changes owner of file


### PR DESCRIPTION
This PR fixes a bug with the Go LDK preventing the `GRPCFile.Close` function from completing on the client side.