### PR TITLE
[SIDE-1917] Add troubleshooting guide

### DIFF
--- a/docs/src/components/menu/desktop-menu.tsx
+++ b/docs/src/components/menu/desktop-menu.tsx
@@ -16,7 +16,7 @@ export const MenuAptitude: React.FunctionComponent<IMenuAptitudeProps> = (props)
   });
 
   return (
-    <li className={styles.sectionItem}>
+    <li className={props.current ? styles.sectionItemCurrent : styles.sectionItem}>
       <Link to={buildAptitudePath(sensor)}>
         <h2 className={styles.sectionItemHeader}>{sensor.name}</h2>
       </Link>
@@ -35,13 +35,16 @@ export const DesktopMenu: React.FunctionComponent<IMenuDetailProps> = (props) =>
       />
     );
   });
-  const guides = mapGuidePages(props.guideList).map((guide) => (
-    <li className={styles.sectionItem}>
-      <Link to={guide.slug}>
-        <h2 className={styles.sectionItemHeader}>{guide.title}</h2>
-      </Link>
-    </li>
-  ));
+  const guides = mapGuidePages(props.guideList).map((guide) => {
+    const current = props.currentPath == guide.slug;
+    return (
+      <li className={current ? styles.sectionItemCurrent : styles.sectionItem}>
+        <Link to={guide.slug}>
+          <h2 className={styles.sectionItemHeader}>{guide.title}</h2>
+        </Link>
+      </li>
+    );
+  });
   return (
     <div className={styles.desktopMenu}>
       <section className={styles.menuSection}>

--- a/docs/src/components/menu/menu.module.scss
+++ b/docs/src/components/menu/menu.module.scss
@@ -27,6 +27,7 @@
 .mobileMenu,
 .desktopMenu {
   background-color: $menuBackgroundColor;
+  background-image: $menuBackgroundImage;
   color: $menuTextColor;
   padding: 20px;
   a {
@@ -63,6 +64,13 @@
 
 .sectionItem {
   padding: 5px 0;
+}
+
+.sectionItem--current {
+  @extend .sectionItem;
+  border-left: $oliveAccentOrange solid 5px;
+  margin-left: -10px;
+  padding: 5px;
 }
 
 .sectionItemHeader {

--- a/docs/src/markdown-pages/troubleshooting.md
+++ b/docs/src/markdown-pages/troubleshooting.md
@@ -1,0 +1,59 @@
+---
+slug: 'guides/troubleshooting'
+title: 'Troubleshooting'
+description: 'Running into problems? We have some ideas that could help!'
+---
+
+So you've ran into some unexpected behaviour and you're not sure how to deal with it? We have some ideas:
+
+## Logs
+
+Olive Helps saves logs, and they often include pertinent information:  
+
+1. Open the Log folder. You can access them in the following locations:
+   * Mac: `~/Library/Logs/Olive Helps`
+   * Windows: `%AppData%\Olive Helps\Logs`
+2. Open the log file for the current Olive Helps version. We generally recommend streaming changes to the log file, 
+   which you can do with the following commands:
+   * Mac Terminal: `tail -n 50 -f Olive\ Helps-X.Y.Z.log`
+   * Windows Powershell: `Get-Content -Tail 50 -Wait -Path ".\Olive Helps.X.Y.Z.log"`
+3. Repeat the steps you followed to generate the problem the first time around. You may need to restart your Loop to do 
+   this. If you find that the application cannot restart the Loop due to an error, restart the application itself. 
+4. If the logging data is inadequate, you can start the application with detailed logging:
+   * Mac Terminal: `LOG_LEVEL=trace open /Applications/Olive\ Helps.app`
+   * Windows Powershell: `$env:LOG_LEVEL='trace'; &"$($env:LOCALAPPDATA)/Olive Helps/olivehelps.exe"`
+   
+## Common Issues
+
+### Cannot Add Local Loop
+
+If you're not able to add a Local Loop successfully, that means that the command you provided could not be successfully 
+run in the directory you selected. Often this is a compilation issue where the program fails to start up successfully. 
+You should check whether the Loop starts up successfully in the Terminal. 
+
+If it is starting up successfully, it should write to `STDOUT` a string in the format `1|1|tcp|{HOST}:{PORT}|grpc`.
+
+If you are using the Go LDK, it should generate this error message instead:
+
+> This binary is a plugin. These are not meant to be executed directly.
+> Please execute the program that consumes these plugins, which will
+> load any plugins automatically
+> exit status 1
+
+
+### MacOS - "Executable File not found in $PATH" Error when Adding Local Loop
+
+This error means that the command you entered for the Loop didn't correspond to an executable that's available under 
+the default `$PATH` environment variable. Often that means you entered a command that works in your terminal like
+`node src/index.js` because your `.zshrc` file adds its location to the `$PATH` variable on launch.
+
+To solve this error, use the direct path to the executable that you're missing. You can get that location with the `which` command:
+```shell
+which node
+```
+
+And then use that path to the executable in the Command field when adding Local Loops:
+
+```shell
+/Users/richardseviora/.nvm/versions/node/v15.7.0/bin/node src/index.js
+```

--- a/docs/src/pages/global.scss
+++ b/docs/src/pages/global.scss
@@ -1,6 +1,32 @@
-$primaryThemeColor: #7C00ED;
+$olivePurple: #7c00ed;
+$oliveDarkPurple: #1f003e;
+$oliveSecondary1: #e5d0ff;
+$oliveSecondary2: #6b00c4;
+$oliveSecondary3: #46007e;
+$oliveNeutral1: #f8f8f8;
+$oliveNeutral2: #d7d7d7;
+
+$oliveAccentGreen: #c4ff00;
+$oliveAccentBlue: #3ecdff;
+$oliveAccentPurple: #9e28b5;
+$oliveAccentMagenta: #ea098b;
+$oliveAccentOrange: #ffa000;
+$oliveAccentYellow: #ffff00;
+
+$primaryThemeColor: $olivePurple;
+
+$mediumGradientStart: $olivePurple;
+$mediumGradientEnd: $oliveSecondary2;
+
+$darkGradientStart: $oliveSecondary2;
+$darkGradientEnd: $oliveSecondary3;
+
+$lightGradientStart: $oliveNeutral1;
+$lightGradientEnd: $oliveNeutral2;
+
 $primaryThemeFade: #833df5;
-$hoverColor: #B388FF;
+$hoverColor: #b388ff;
+$codeBorderColor: #e8dbff;
 $lightestAccent: #faf6ff;
 
 $primaryFont: sofia-pro, sans-serif;
@@ -16,7 +42,9 @@ $bodyFontSize: 16px;
 $bodyFontWeight: 500;
 
 $headerBackgroundColor: $primaryThemeColor;
-$headerBackgroundImage: linear-gradient($primaryThemeColor, $primaryThemeFade);
+$headerBackgroundImage: linear-gradient($mediumGradientStart, $mediumGradientEnd);
+
+$menuBackgroundImage: linear-gradient(to bottom left, $darkGradientStart, $darkGradientEnd);
 
 $menuBackgroundColor: $primaryThemeColor;
 $menuTextColor: white;

--- a/docs/src/pages/index.scss
+++ b/docs/src/pages/index.scss
@@ -20,3 +20,39 @@ a:hover {
   color: $hoverColor;
   text-decoration: underline;
 }
+
+code {
+  border: 1px solid $codeBorderColor;
+  margin: 0 2px;
+  padding: 0 5px;
+}
+
+pre {
+  border: 1px solid $hoverColor;
+  padding: 4px 8px;
+}
+
+code,
+pre {
+  color: $oliveSecondary3;
+  font-family: monospace;
+  background-color: $lightestAccent;
+  border-radius: 3px;
+}
+
+pre > code {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+ol > li {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+blockquote {
+  margin: 1rem 0;
+  border-left: 5px solid $oliveNeutral2;
+  padding-left: .6rem;
+}


### PR DESCRIPTION
This PR:

- Adds a quick troubleshooting guide with some of the common troubleshooting steps and questions I've encountered so far.
- Adds the updated brand colours to the global styles file.
- Adds styles for the code blocks elements (both inline and block level)
- Used the dark purple gradient for the desktop menu.
- Adds a visual indicator for the current page.