### PR TITLE
use WindowEvent for listenAll method

### DIFF
--- a/ldk/goja/src/types/oliveHelps/index.d.ts
+++ b/ldk/goja/src/types/oliveHelps/index.d.ts
@@ -1,3 +1,4 @@
+
 /* eslint-disable */
 declare module 'fastestsmallesttextencoderdecoder';
 declare const oliveHelps: OliveHelps.Aptitudes;
@@ -24,13 +25,29 @@ declare namespace OliveHelps {
 
     all(cb: (windowInfos: WindowInfo[]) => void): void;
 
-    listenAll(cb: (windowInfo: WindowInfo) => void): void;
+    listenAll(cb: (windowEvent: WindowEvent) => void): void;
   }
 
   interface WindowEvent {
     info: WindowInfo;
-    action: number;
+    action: WindowAction;
   }
+  type WindowActionFocused = "focus"
+  type WindowActionUnfocused = "unfocused"
+  type WindowActionOpened = "open"
+  type WindowActionClosed = "close"
+  type WindowActionMoved = "move"
+  type WindowActionResized = "resized"
+  type WindowActionTitleChanged = "titleChange"
+
+  type WindowAction =
+    WindowActionFocused
+    | WindowActionUnfocused
+    | WindowActionOpened
+    | WindowActionClosed
+    | WindowActionMoved
+    | WindowActionResized
+    | WindowActionTitleChanged
 
   interface WindowInfo {
     title: string;

--- a/ldk/goja/src/window/index.ts
+++ b/ldk/goja/src/window/index.ts
@@ -10,8 +10,25 @@ export interface WindowInfo {
 
 export interface WindowEvent {
     info: WindowInfo;
-    action: number;
+    action: WindowAction;
 }
+
+export type WindowActionFocused = "focus"
+export type WindowActionUnfocused = "unfocused"
+export type WindowActionOpened = "open"
+export type WindowActionClosed = "close"
+export type WindowActionMoved = "move"
+export type WindowActionResized = "resized"
+export type WindowActionTitleChanged = "titleChange"
+
+export type WindowAction =
+      WindowActionFocused 
+    | WindowActionUnfocused
+    | WindowActionOpened
+    | WindowActionClosed
+    | WindowActionMoved
+    | WindowActionResized
+    | WindowActionTitleChanged
 
 export interface Window {
     /**
@@ -40,7 +57,7 @@ export interface Window {
      *  
      * @param callback A function called when any window changes.
      */
-    listenAll(callback: (windowInfo: WindowInfo) => void): void;
+    listenAll(callback: (windowEvent: WindowEvent) => void): void;
 }
 
 function activeWindow(): Promise<WindowInfo> {
@@ -69,7 +86,7 @@ function all(): Promise<WindowInfo[]> {
     });
 }
 
-function listenAll(callback: (windowInfo: WindowInfo) => void): void {
+function listenAll(callback: (windowEvent: WindowEvent) => void): void {
     oliveHelps.window.listenAll(callback);
 }
 

--- a/ldk/goja/src/window/index.ts
+++ b/ldk/goja/src/window/index.ts
@@ -8,11 +8,6 @@ export interface WindowInfo {
     height: number;
 }
 
-export interface WindowEvent {
-    info: WindowInfo;
-    action: WindowAction;
-}
-
 export type WindowActionFocused = "focus"
 export type WindowActionUnfocused = "unfocused"
 export type WindowActionOpened = "open"
@@ -29,6 +24,11 @@ export type WindowAction =
     | WindowActionMoved
     | WindowActionResized
     | WindowActionTitleChanged
+
+export interface WindowEvent {
+    info: WindowInfo;
+    action: WindowAction;
+}
 
 export interface Window {
     /**


### PR DESCRIPTION
This updates the window.listenAll method to send back a WindowEvent instead of WindowInfo.