### PR TITLE
SIDE-2138: add CNAME file with oliveai.dev

### DIFF
--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+oliveai.dev


### PR DESCRIPTION
### Issue
oliveai.dev keeps resetting custom domain on deployments of the docs to olive-helps github pages.

### Solution
Add CNAME file with oliveai.dev so that deployments don't remove the custom domain setting from the olive-helps github page. Adding the CNAME file to the static directory means the docs build process automatically copies it to the root directory (which is where github needs it to be).