### PR TITLE
[SIDE-2123] Fix Runtime Polyfills

### DIFF
--- a/ldk/javascript/examples/javascript-loop/package.json
+++ b/ldk/javascript/examples/javascript-loop/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack --entry core-js/fn/promise --entry ./index.js --config ./node_modules/@oliveai/ldk/dist/webpack/config.js"
+    "build": "webpack --entry ./index.js --config ./node_modules/@oliveai/ldk/dist/webpack/config.js"
   },
   "author": "LDK Team",
   "license": "ISC",

--- a/ldk/javascript/examples/self-test-loop/webpack.config.js
+++ b/ldk/javascript/examples/self-test-loop/webpack.config.js
@@ -5,7 +5,7 @@ const ldkConfig = require('@oliveai/ldk/dist/webpack/config');
 /* eslint-disable */
 
 const merged = merge.merge(ldkConfig.default, {
-  entry: [path.resolve(__dirname, './src/index.ts'), 'core-js/features/symbol'],
+  entry: [path.resolve(__dirname, './src/index.ts')],
 });
 
 module.exports = merged;

--- a/ldk/javascript/examples/typescript-loop/package.json
+++ b/ldk/javascript/examples/typescript-loop/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack --entry core-js/fn/promise --entry ./index.ts --config ./node_modules/@oliveai/ldk/dist/webpack/config.js"
+    "build": "webpack --entry ./index.ts --config ./node_modules/@oliveai/ldk/dist/webpack/config.js"
   },
   "author": "LDK Team",
   "license": "ISC",

--- a/ldk/javascript/package-lock.json
+++ b/ldk/javascript/package-lock.json
@@ -925,6 +925,13 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        }
       }
     },
     "@babel/template": {
@@ -2747,9 +2754,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.1.tgz",
+      "integrity": "sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ=="
     },
     "core-js-compat": {
       "version": "3.10.1",

--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -58,6 +58,7 @@
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs2": "^7.13.10",
     "babel-loader": "^8.2.2",
+    "core-js": "^2.6.12",
     "terser-webpack-plugin": "^5.1.1",
     "text-encoding-shim": "^1.0.5",
     "webpack": "^5.28.0",

--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -58,7 +58,7 @@
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs2": "^7.13.10",
     "babel-loader": "^8.2.2",
-    "core-js": "^2.6.12",
+    "core-js": "^3.11.1",
     "terser-webpack-plugin": "^5.1.1",
     "text-encoding-shim": "^1.0.5",
     "webpack": "^5.28.0",

--- a/ldk/javascript/readme.md
+++ b/ldk/javascript/readme.md
@@ -8,7 +8,7 @@ We recommend using Webpack 5 to compile your Loop code for you. Our Webpack conf
 Install Webpack 5 and its CLI, and add this build script to your `package.json`:
 
 ```shell
-webpack --entry core-js/fn/promise --entry ./index.js --config ./node_modules/@oliveai/ldk/dist/webpack/config.js
+webpack --entry ./index.js --config ./node_modules/@oliveai/ldk/dist/webpack/config.js
 ```
 
 This will use the LDK webpack configuration and compile the file to the `./dist/loop.js` directory.

--- a/ldk/javascript/src/index.ts
+++ b/ldk/javascript/src/index.ts
@@ -1,3 +1,4 @@
+import "core-js";
 import * as clipboard from './clipboard';
 import * as cursor from './cursor';
 import * as filesystem from './filesystem';

--- a/ldk/javascript/src/webpack/config.ts
+++ b/ldk/javascript/src/webpack/config.ts
@@ -45,7 +45,7 @@ const config: webpack.Configuration = {
                 [
                   '@babel/preset-env',
                   {
-                    useBuiltIns: 'usage',
+                    useBuiltIns: 'entry',
                     corejs: '2.6',
                   },
                 ],
@@ -68,7 +68,7 @@ const config: webpack.Configuration = {
               [
                 '@babel/preset-env',
                 {
-                  useBuiltIns: 'usage',
+                  useBuiltIns: 'entry',
                   corejs: '2.6',
                 },
               ],

--- a/ldk/javascript/src/webpack/config.ts
+++ b/ldk/javascript/src/webpack/config.ts
@@ -4,7 +4,6 @@ import Terser from 'terser-webpack-plugin';
 import { generateBanner } from './generate-banner';
 
 const config: webpack.Configuration = {
-  entry: ['core-js/fn/promise'],
   target: ['web', 'es5'],
   output: {
     path: path.join(process.cwd(), 'dist'),
@@ -37,7 +36,25 @@ const config: webpack.Configuration = {
     rules: [
       {
         test: /\.ts$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              sourceType: 'unambiguous',
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    useBuiltIns: 'usage',
+                    corejs: '2.6',
+                  },
+                ],
+              ],
+              plugins: ['@babel/plugin-transform-destructuring', '@babel/plugin-transform-runtime'],
+            },
+          },
+          { loader: 'ts-loader' },
+        ],
         exclude: /node_modules/,
       },
       {
@@ -47,7 +64,15 @@ const config: webpack.Configuration = {
           loader: 'babel-loader',
           options: {
             sourceType: 'unambiguous',
-            presets: ['@babel/preset-env'],
+            presets: [
+              [
+                '@babel/preset-env',
+                {
+                  useBuiltIns: 'usage',
+                  corejs: '2.6',
+                },
+              ],
+            ],
             plugins: ['@babel/plugin-transform-destructuring', '@babel/plugin-transform-runtime'],
           },
         },

--- a/ldk/javascript/src/webpack/config.ts
+++ b/ldk/javascript/src/webpack/config.ts
@@ -46,7 +46,7 @@ const config: webpack.Configuration = {
                   '@babel/preset-env',
                   {
                     useBuiltIns: 'entry',
-                    corejs: '2.6',
+                    corejs: '3.11',
                   },
                 ],
               ],
@@ -69,7 +69,7 @@ const config: webpack.Configuration = {
                 '@babel/preset-env',
                 {
                   useBuiltIns: 'entry',
-                  corejs: '2.6',
+                  corejs: '3.11',
                 },
               ],
             ],


### PR DESCRIPTION
This PR does a number of things:

- Updates the way that we polyfill modern capabilities into the environment so that the user doesn't need to add incrementally new polyfills (like `Symbol.asyncIterator`) as they add more features. This comes at the cost of an increased compilation size.
- Removes the `core-js` entries from the config.
- Uses Babel to transpile TS too.