### PR TITLE
SIDE-2160: Whisper Return Object in all Component Callbacks 

### DIFF
--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -258,6 +258,11 @@ declare namespace OliveHelps {
     Right = 'right',
   }
 
+  interface Whisper {
+    id: string;
+    close(cb: (err: string) => void): void;
+    // update(whisper: NewWhisper, cb: (err: string) => void): void // TODO: Implement 
+  }
   interface Component<T extends WhisperComponentType> {
     id?: string;
     type: T;
@@ -394,11 +399,6 @@ declare namespace OliveHelps {
     onClose: () => void;
   }
 
-  interface Whisper {
-    id: string;
-    close(cb: (err: string) => void): void;
-    // update(whisper: NewWhisper, cb: (err: string) => void): void // TODO: Implement 
-  }
 
   interface FileInfo {
     name: string;

--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -200,8 +200,6 @@ declare namespace OliveHelps {
   //-- Whisper
   interface WhisperService {
     create: ReadableWithParam<NewWhisper, Whisper>;
-
-    all: Readable<Whisper[]>;
   }
 
   enum WhisperComponentType {
@@ -256,19 +254,19 @@ declare namespace OliveHelps {
 
   type Button = Component<WhisperComponentType.Button> & {
     label: string;
-    onClick: () => void;
+    onClick: (whisper: Whisper) => void;
   };
 
   type Checkbox = Component<WhisperComponentType.Checkbox> & {
     label: string;
     tooltip?: string;
     value: boolean;
-    onChange: (value: boolean) => void;
+    onChange: (value: boolean, whisper: Whisper) => void;
   };
 
   type Email = Component<WhisperComponentType.Email> & {
     label: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, whisper: Whisper) => void;
     tooltip?: string;
     value?: string;
   };
@@ -276,7 +274,7 @@ declare namespace OliveHelps {
   type Link = Component<WhisperComponentType.Link> & {
     href?: string;
     text: string;
-    onClick?: () => void;
+    onClick?: (whisper: Whisper) => void;
     style?: Urgency;
     textAlign?: TextAlign;
   };
@@ -301,7 +299,7 @@ declare namespace OliveHelps {
 
   type NumberInput = Component<WhisperComponentType.Number> & {
     label: string;
-    onChange: (value: number) => void;
+    onChange: (value: number, whisper: Whisper) => void;
     value?: number;
     max?: number;
     min?: number;
@@ -311,13 +309,13 @@ declare namespace OliveHelps {
 
   type Password = Component<WhisperComponentType.Password> & {
     label: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, whisper: Whisper) => void;
     tooltip?: string;
     value?: string;
   };
 
   type RadioGroup = Component<WhisperComponentType.RadioGroup> & {
-    onSelect: (value: number) => void;
+    onSelect: (value: number, whisper: Whisper) => void;
     options: string[];
     selected?: number;
   };
@@ -325,14 +323,14 @@ declare namespace OliveHelps {
   type Select = Component<WhisperComponentType.Select> & {
     label: string;
     options: string[];
-    onSelect: (value: number) => void;
+    onSelect: (value: number, whisper: Whisper) => void;
     selected?: number;
     tooltip?: string;
   };
 
   type Telephone = Component<WhisperComponentType.Telephone> & {
     label: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, whisper: Whisper) => void;
     // pattern?: RegExp; TODO: Implement this
     tooltip?: string;
     value?: string;
@@ -340,7 +338,7 @@ declare namespace OliveHelps {
 
   type TextInput = Component<WhisperComponentType.TextInput> & {
     label: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, whisper: Whisper) => void;
     tooltip?: string;
     value?: string;
   };
@@ -385,9 +383,8 @@ declare namespace OliveHelps {
 
   interface Whisper {
     id: string;
-    label: string;
-    components: Array<Components>;
-    close(cb: () => void): void;
+    close(cb: (err: string) => void): void;
+    // update(whisper: NewWhisper, cb: (err: string) => void): void // TODO: Implement 
   }
 
   interface FileInfo {

--- a/ldk/javascript/src/whisper/index.ts
+++ b/ldk/javascript/src/whisper/index.ts
@@ -95,19 +95,19 @@ export interface WhisperComponent<T extends WhisperComponentType> {
 
 export declare type Button = WhisperComponent<WhisperComponentType.Button> & {
   label: string;
-  onClick: () => void;
+  onClick: (whisper: Whisper) => void;
 };
 
 export declare type Checkbox = WhisperComponent<WhisperComponentType.Checkbox> & {
   label: string;
   tooltip?: string;
   value: boolean;
-  onChange: (value: boolean) => void;
+  onChange: (value: boolean, whisper: Whisper) => void;
 };
 
 export declare type Email = WhisperComponent<WhisperComponentType.Email> & {
   label: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, whisper: Whisper) => void;
   tooltip?: string;
   value?: string;
 };
@@ -115,7 +115,7 @@ export declare type Email = WhisperComponent<WhisperComponentType.Email> & {
 export declare type Link = WhisperComponent<WhisperComponentType.Link> & {
   href?: string;
   text: string;
-  onClick?: () => void;
+  onClick?: (whisper: Whisper) => void;
   style?: Urgency;
   textAlign?: TextAlign;
 };
@@ -140,7 +140,7 @@ export declare type Message = WhisperComponent<WhisperComponentType.Message> & {
 
 export declare type NumberInput = WhisperComponent<WhisperComponentType.Number> & {
   label: string;
-  onChange: (value: number) => void;
+  onChange: (value: number, whisper: Whisper) => void;
   value?: number;
   max?: number;
   min?: number;
@@ -150,13 +150,13 @@ export declare type NumberInput = WhisperComponent<WhisperComponentType.Number> 
 
 export declare type Password = WhisperComponent<WhisperComponentType.Password> & {
   label: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, whisper: Whisper) => void;
   tooltip?: string;
   value?: string;
 };
 
 export declare type RadioGroup = WhisperComponent<WhisperComponentType.RadioGroup> & {
-  onSelect: (value: number) => void;
+  onSelect: (value: number, whisper: Whisper) => void;
   options: string[];
   selected?: number;
 };
@@ -164,14 +164,14 @@ export declare type RadioGroup = WhisperComponent<WhisperComponentType.RadioGrou
 export declare type Select = WhisperComponent<WhisperComponentType.Select> & {
   label: string;
   options: string[];
-  onSelect: (value: number) => void;
+  onSelect: (value: number, whisper: Whisper) => void;
   selected?: number;
   tooltip?: string;
 };
 
 export declare type Telephone = WhisperComponent<WhisperComponentType.Telephone> & {
   label: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, whisper: Whisper) => void;
   // pattern?: RegExp; TODO: Implement this
   tooltip?: string;
   value?: string;
@@ -179,7 +179,7 @@ export declare type Telephone = WhisperComponent<WhisperComponentType.Telephone>
 
 export declare type TextInput = WhisperComponent<WhisperComponentType.TextInput> & {
   label: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, whisper: Whisper) => void;
   tooltip?: string;
   value?: string;
 };
@@ -224,17 +224,11 @@ export interface NewWhisper {
 
 export interface Whisper {
   id: string;
-  label: string;
-  components: Array<Components>;
-  close(callback: () => void): void;
+  close(cb:(err: string) => void): void;
+  // update(whisper: NewWhisper, cb: (err: string) => void): void
 }
 
 export interface WhisperAptitude {
-  /**
-   * Returns a promise which provides a list of all of the current whispers in Olive Helps
-   */
-  all(): Promise<Whisper[]>;
-
   /**
    * Adds a new whisper to Olive Helps based on the configuration provided.
    * Returns a promise which provides a reference to the newly created whisper
@@ -242,10 +236,6 @@ export interface WhisperAptitude {
    * @param whisper The configuration for the whisper being created
    */
   create(whisper: NewWhisper): Promise<Whisper>;
-}
-
-export function all(): Promise<Whisper[]> {
-  return promisify(oliveHelps.whisper.all);
 }
 
 export function create(whisper: NewWhisper): Promise<Whisper> {

--- a/ldk/javascript/src/whisper/index.ts
+++ b/ldk/javascript/src/whisper/index.ts
@@ -1,4 +1,4 @@
-import { promisify, promisifyWithParam } from '../promisify';
+import { promisifyWithParam } from '../promisify';
 
 export enum WhisperComponentType {
   /**
@@ -97,6 +97,12 @@ export enum Urgency {
   None = 'none',
   Success = 'success',
   Warning = 'warning',
+}
+
+export interface Whisper {
+  id: string;
+  close(cb:(err: string) => void): void;
+  // update(whisper: NewWhisper, cb: (err: string) => void): void
 }
 
 export interface WhisperComponent<T extends WhisperComponentType> {
@@ -233,12 +239,6 @@ export interface NewWhisper {
   components: Array<Components>;
   label: string;
   onClose: () => void;
-}
-
-export interface Whisper {
-  id: string;
-  close(cb:(err: string) => void): void;
-  // update(whisper: NewWhisper, cb: (err: string) => void): void
 }
 
 export interface WhisperAptitude {

--- a/ldk/javascript/src/whisper/whisper.test.ts
+++ b/ldk/javascript/src/whisper/whisper.test.ts
@@ -4,48 +4,10 @@ import * as whisper from '.';
 describe('Whisper', () => {
   beforeEach(() => {
     oliveHelps.whisper = {
-      all: jest.fn(),
       create: jest.fn(),
     };
   });
 
-  describe('all', () => {
-    it('Returns an array of all current whispers', () => {
-      const expected: whisper.Whisper[] = [
-        {
-          components: [
-            {
-              body: 'Test',
-              id: '1',
-              type: whisper.WhisperComponentType.Markdown,
-            },
-          ],
-          close: () => {
-            console.log();
-          },
-          id: '1',
-          label: 'Test',
-        },
-      ];
-      mocked(oliveHelps.whisper.all).mockImplementation((callback) => callback(expected));
-
-      const actual = whisper.all();
-
-      expect(oliveHelps.whisper.all).toHaveBeenCalled();
-      return expect(actual).resolves.toBe(expected);
-    });
-
-    it('returns a rejected promise', () => {
-      const exception = 'Exception';
-      mocked(oliveHelps.whisper.all).mockImplementation(() => {
-        throw exception;
-      });
-
-      const actual = whisper.all();
-
-      return expect(actual).rejects.toBe(exception);
-    });
-  });
 
   describe('create', () => {
     it('Creates a whisper', () => {
@@ -62,18 +24,10 @@ describe('Whisper', () => {
       };
 
       const expected: whisper.Whisper = {
-        components: [
-          {
-            body: 'Test',
-            id: '1',
-            type: whisper.WhisperComponentType.Markdown,
-          },
-        ],
         close: () => {
           console.log();
         },
         id: '1',
-        label: 'Test',
       };
 
       mocked(oliveHelps.whisper.create).mockImplementation((_whisper, callback) =>


### PR DESCRIPTION
Passing the whisper object back with all component callbacks will allow loop authors to utilize the `close` and eventually the `update` methods inside of the components callbacks.

Note: This PR also removes the `all` method from the whisper service.  The `all` method was left over from the thinking that whispers would have to be persisted through a loop shut down. 

- Also add an error parameter to the close method on the whisper object