### PR TITLE
SIDE-2130b: updated getting started link

### DIFF
--- a/docs/src/markdown-pages/guides/submitting-loop.md
+++ b/docs/src/markdown-pages/guides/submitting-loop.md
@@ -9,7 +9,7 @@ description: 'Submit your Loop for review and approval by the Olive Helps team.'
 1. Install the most recent version of the Olive Helps app from [the Developer Hub](https://open-olive.github.io/olive-helps/)
 1. Open the Olive Helps application and navigate to the **Loop Library** from the sidebar (found within the hamburger menu and at the bottom right of the sidebar)
 1. Within the Loop Library window, you should see a **Loop Authors** section on the bottom left within the navigation menu. Assuming you have author permissions, you can navigate to **Submit New Loop**.
-    - If you are not a Loop Author and you do not see **Submit New Loop**, please see [becoming a Loop Author](./getting-started.md#getting-started).
+    - If you are not a Loop Author and you do not see **Submit New Loop**, please see [becoming a Loop Author section](./getting-started).
 1. Within the **Submit New Loop** page, you should fill out any necessary metadata. You can also select whether you want this Loop accessible to just your organization or publicly available here. The last field on this page is the Loop directory and you will need point it to the location of your `loop.js` file which is `$PROJECT_LOCATION/dist` from step 1.
 1. Click **Submit Loop** to begin the loop review process. You should receive an email shortly letting you know someone is taking a look!
 1. You can make corrections/updates to this Loop within the **My Authored Loops** page which is right above **Submit New Loop**. Click on the …menu to submit a new version which is found on the top right of any Loop card.


### PR DESCRIPTION
The link for "becoming a Loop author" was broken. This should fix it.