### PR TITLE
[SIDE-2236] Fix hotkey matching logic

### DIFF
--- a/ldk/go/keyboardService.go
+++ b/ldk/go/keyboardService.go
@@ -40,13 +40,13 @@ type KeyModifierGroup struct {
 
 func (k KeyModifierGroup) MatchesActual(a KeyModifierGroup) bool {
 	// Even if either is set to false, it should be OK if left OR right is pressed.
-	eitherPass := k.Either == a.Either || (k.Either == false && (a.Left || a.Right))
+	eitherPass := k.Either == a.Either || (!k.Either && (a.Left || a.Right))
 	// If Left is set to false, Either is still fine on the actual because it can be set by right.
-	leftMatch := k.Left == a.Left || (k.Left == false && a.Either)
+	leftMatch := k.Left == a.Left || (!k.Left && a.Either)
 	// If Right is set to false, Either is still fine on the actual because it will be true if left key is pressed.
-	rightMatch := k.Right == a.Right || (k.Right == false && a.Either)
+	rightMatch := k.Right == a.Right || (!k.Right && a.Either)
 	excludeAllMatch := true
-	if k.Either == k.Left == k.Right == false {
+	if !k.Either == k.Left == k.Right {
 		excludeAllMatch = !(a.Left || a.Either || a.Right)
 	}
 	return eitherPass && leftMatch && rightMatch && excludeAllMatch

--- a/ldk/go/keyboardService.go
+++ b/ldk/go/keyboardService.go
@@ -45,7 +45,11 @@ func (k KeyModifierGroup) MatchesActual(a KeyModifierGroup) bool {
 	leftMatch := k.Left == a.Left || (k.Left == false && a.Either)
 	// If Right is set to false, Either is still fine on the actual because it will be true if left key is pressed.
 	rightMatch := k.Right == a.Right || (k.Right == false && a.Either)
-	return eitherPass && leftMatch && rightMatch
+	excludeAllMatch := true
+	if k.Either == k.Left == k.Right == false {
+		excludeAllMatch = !(a.Left || a.Either || a.Right)
+	}
+	return eitherPass && leftMatch && rightMatch && excludeAllMatch
 }
 
 type KeyModifier int

--- a/ldk/go/keyboardService_test.go
+++ b/ldk/go/keyboardService_test.go
@@ -74,24 +74,25 @@ func TestHotKeyMatch(t *testing.T) {
 		name      string
 	}{
 		{
-			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
-			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
-			expected:  true,
-		},
-		{
 			name:      "alt vs alt+shift",
 			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
 			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierShift},
 			expected:  false,
 		},
 		{
-			name:      "alt+shift vs alt",
-			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierShift | ldk.KeyModifierCommandAltLeft},
+			name:      "do not permit if missing",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierShift},
+			expected:  false,
+		},
+		{
+			name:      "do not permit if superset is pressed",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft | ldk.KeyModifierShift | ldk.KeyModifierShiftLeft},
 			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
 			expected:  false,
 		},
 		{
-			name:      "altleft vs altright",
+			name:      "altright vs altleft",
 			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
 			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltRight},
 			expected:  false,
@@ -103,7 +104,7 @@ func TestHotKeyMatch(t *testing.T) {
 			expected:  true,
 		},
 		{
-			name:      "alt vs alt+shift",
+			name:      "altleft vs altright",
 			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltRight},
 			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltLeft},
 			expected:  false,

--- a/ldk/go/keyboardService_test.go
+++ b/ldk/go/keyboardService_test.go
@@ -1,6 +1,7 @@
 package ldk_test
 
 import (
+	"fmt"
 	"reflect"
 	"runtime"
 	"testing"
@@ -50,7 +51,7 @@ func TestKeyModifiers(t *testing.T) {
 				for j, fn := range funcs {
 					fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 					if i == j {
-						t.Logf("testing %d -> %s", bit, fnName)
+						// t.Logf("testing %d -> %s", bit, fnName)
 						if !fn(ldk.KeyModifier(bit)) {
 							t.Errorf("%s not detected for %d", test.name, bit)
 						}
@@ -60,6 +61,75 @@ func TestKeyModifiers(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestHotKeyMatch(t *testing.T) {
+	tests := []struct {
+		actual    ldk.Hotkey
+		requested ldk.Hotkey
+		expected  bool
+		name      string
+	}{
+		{
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
+			expected:  true,
+		},
+		{
+			name:      "alt vs alt+shift",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierShift},
+			expected:  false,
+		},
+		{
+			name:      "alt+shift vs alt",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierShift | ldk.KeyModifierCommandAltLeft},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
+			expected:  false,
+		},
+		{
+			name:      "altleft vs altright",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltRight},
+			expected:  false,
+		},
+		{
+			name:      "altleft vs alteither",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltLeft},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
+			expected:  true,
+		},
+		{
+			name:      "alt vs alt+shift",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt | ldk.KeyModifierCommandAltRight},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltLeft},
+			expected:  false,
+		},
+		{
+			name:      "alt vs left alt",
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltLeft | ldk.KeyModifierCommandAlt},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltLeft},
+			expected:  true,
+		},
+		{
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltRight | ldk.KeyModifierCommandAlt},
+			requested: ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAltLeft},
+			expected:  false,
+		},
+		{
+			actual:    ldk.Hotkey{Key: 'a', Modifiers: ldk.KeyModifierCommandAlt},
+			requested: ldk.Hotkey{Key: 'b', Modifiers: ldk.KeyModifierCommandAlt},
+			expected:  false,
+		},
+	}
+	for idx, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%v %v", test.name, idx), func(t *testing.T) {
+			if test.requested.Match(test.actual) != test.expected {
+				t.Errorf("Received Error on Keycombination actual %#v vs. requested %#v, it should have returned %#v", test.actual, test.requested, test.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This PR:

- Reworks the Hotkey matching logic so that it prevents matches when the actual keypress is a superset of the requested keypress.
- Adds some tests to validate the above.