### PR TITLE
Fix issue where permissions error not thrown

### DIFF
--- a/ldk/javascript/src/webpack/generate-banner.test.ts
+++ b/ldk/javascript/src/webpack/generate-banner.test.ts
@@ -89,10 +89,15 @@ describe('Generate Banner', () => {
         expect(result.oliveHelpsContractVersion).toEqual('0.1.0');
     });
 
-    it('throws exception when LdkSettings are not provided', () => {
+    it('throws exception when LDK permissions are not provided', () => {
         const invalidLdkSettings: LdkSettings = { ldk: {} as Ldk }
 
         expect(() => generateBanner(invalidLdkSettings))
             .toThrowError(expectedErrorMessage);
+    });
+
+    it('throws exception when LDK key is not specified', () => {
+        expect(() => generateBanner(<LdkSettings>{}))
+          .toThrowError(expectedErrorMessage);
     });
 });

--- a/ldk/javascript/src/webpack/generate-banner.ts
+++ b/ldk/javascript/src/webpack/generate-banner.ts
@@ -8,7 +8,7 @@ const permissionsErrorMessage =
 See README for more information.`
 
 export function generateMetadata(ldkSettings: LdkSettings): string {
-  if(Object.keys(ldkSettings.ldk).length === 0) {
+  if(!ldkSettings || !ldkSettings.ldk || Object.keys(ldkSettings.ldk).length === 0) {
     throw new Error(permissionsErrorMessage);
   }
   const json = JSON.stringify({


### PR DESCRIPTION
Previously, if package.json did not include an "LDK" key a  TypeError: Cannot convert undefined or null to object would be thrown.