### PR TITLE
SIDE-2273: Adding self-test for directory exists on the filesystem

### DIFF
--- a/ldk/javascript/examples/self-test-loop/package.json
+++ b/ldk/javascript/examples/self-test-loop/package.json
@@ -35,6 +35,9 @@
           },
           {
             "value": "./test.txt"
+          },
+          {
+            "value": "./test-tmp-dir"
           }
         ]
       },

--- a/ldk/javascript/examples/self-test-loop/src/selfTest.ts
+++ b/ldk/javascript/examples/self-test-loop/src/selfTest.ts
@@ -34,6 +34,7 @@ import {
   updateAndReadFile,
   listenFile,
   listenDir,
+  dirExists,
 } from './tests';
 
 const testConfig: { [key: string]: TestGroup } = {
@@ -229,6 +230,12 @@ const testConfig: { [key: string]: TestGroup } = {
       listenDir,
       10000,
       'Monitoring for dir change...',
+    ),
+    new LoopTest(
+      'File Aptitude - Dir Exists',
+      dirExists,
+      10000,
+      'Checking for directory existence...',
     ),
   ]),
 };

--- a/ldk/javascript/examples/self-test-loop/src/selfTest.ts
+++ b/ldk/javascript/examples/self-test-loop/src/selfTest.ts
@@ -35,6 +35,7 @@ import {
   listenFile,
   listenDir,
   dirExists,
+  fileExists
 } from './tests';
 
 const testConfig: { [key: string]: TestGroup } = {
@@ -236,6 +237,12 @@ const testConfig: { [key: string]: TestGroup } = {
       dirExists,
       10000,
       'Checking for directory existence...',
+    ),
+    new LoopTest(
+      'File Aptitude - File Exists',
+      fileExists,
+      10000,
+      'Checking for file existence...',
     ),
   ]),
 };

--- a/ldk/javascript/examples/self-test-loop/src/tests/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/index.ts
@@ -486,6 +486,30 @@ export const dirExists = (): Promise<boolean> =>
     });
   });
 
+export const fileExists = (): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    const filePath = './test_listenDir.txt';
+    const writeMode = 0o755;
+    network.encode('some file text').then((encodedValue) => {
+      filesystem.writeFile({
+        path: filePath,
+        data: encodedValue,
+        writeOperation: filesystem.WriteOperation.overwrite,
+        writeMode: writeMode,
+      }).then(() => {
+        filesystem.exists(filePath).then(exists => {
+          filesystem.remove(filePath);
+          if (exists === true) {
+            resolve(true);
+          }
+          reject('Could not check if directory exists');
+        });
+      }).catch((error) => {
+        reject(error);
+      });
+    });
+  });
+
 export const testNetworkAndListComponents = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
     const url = `https://api.fda.gov/food/enforcement.json?search=report_date:[20210101+TO+20210401]&limit=1`;

--- a/ldk/javascript/examples/self-test-loop/src/tests/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/index.ts
@@ -471,6 +471,21 @@ export const listenDir = (): Promise<boolean> =>
       });
   });
 
+export const dirExists = (): Promise<boolean> => 
+  new Promise((resolve, reject) => {
+    const destination = './test-tmp-dir';
+    const writeMode = 0o755;
+    filesystem.makeDir(destination, writeMode).then(() => {
+      filesystem.exists(destination).then(exists => {
+        filesystem.remove(destination);
+        if (exists === true) {
+          resolve(true);
+        }
+        reject('Could not check if directory exists');
+      });
+    });
+  });
+
 export const testNetworkAndListComponents = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
     const url = `https://api.fda.gov/food/enforcement.json?search=report_date:[20210101+TO+20210401]&limit=1`;

--- a/ldk/javascript/package-lock.json
+++ b/ldk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oliveai/ldk",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oliveai/ldk",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.13.10",


### PR DESCRIPTION
We noticed that directory exists was not working properly a few days ago, in my investigation, I added a new self-test around the existence of a directory to investigate.

Upon updating to the latest sidekick, I see that a fix had already been made to the production code there. (versions of OH > OH > v0.17.3)

I have a testing counterpart PR opened with sidekick that can be reviewed separately.