### PR TITLE
SIDE-2212: Support markdown for checkbox and radio components

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/index.ts
@@ -152,6 +152,7 @@ export const processStream = (): Promise<boolean> =>
 
 export const testMarkdownWhisper = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
+    const options = ['M12.01', 'M00.123']
     var form: whisper.Whisper;
     whisper
       .create({
@@ -177,6 +178,58 @@ export const testMarkdownWhisper = (): Promise<boolean> =>
               | Row 2 Col 1 | Row 2 Col 2 |
               `,
             type: whisper.WhisperComponentType.Markdown,
+          },
+          {
+            label: `${options[0]}  
+            line one
+            line two 100.0%`,
+            value: false,
+            onChange: (error, value) => {
+              console.debug(`selected value: ${options[0]}`);
+            },
+            type: whisper.WhisperComponentType.Checkbox,
+          },
+          {
+            label: `${options[1]}  
+            this is a longer line one, it was known for being long 
+            99.2 %`,
+            value: false,
+            onChange: () => {
+              console.debug(`selected value: ${options[1]}`);
+            },
+            type: whisper.WhisperComponentType.Checkbox,
+          },
+          {
+            label: `Single Line Example that is extremely 
+            long extremely long extremely long extremely 
+            long extremely long extremely long extremely long extremely 
+            long extremely long extremely long extremely long extremely 
+            long extremely long extremely long`,
+            value: false,
+            onChange: () => {
+            },
+            type: whisper.WhisperComponentType.Checkbox,
+          },
+          {
+            label: `normal label with no surprises`,
+            value: false,
+            onChange: () => {
+            },
+            type: whisper.WhisperComponentType.Checkbox,
+          },
+          {
+            onSelect: (selected) => {
+              console.log(`${selected} has been selected!`);
+            },
+            options: [
+              'no markdown', 
+              '**Strong Option**', 
+              `multiline  
+              line 1  
+              line 2`
+            ],
+            selected: 0,
+            type: whisper.WhisperComponentType.RadioGroup,
           },
           {
             alignment: whisper.Alignment.SpaceEvenly,
@@ -753,6 +806,7 @@ export const simpleFormWhisper = (): Promise<boolean> =>
 
 export const numberInputs = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
+    var form: whisper.Whisper;
     const config: whisper.NewWhisper = {
       label: 'Number Test',
       components: [
@@ -791,8 +845,10 @@ export const numberInputs = (): Promise<boolean> =>
         console.log('close');
       },
     };
-    whisper.create(config).then(() => {
+    whisper.create(config).then((whisper: whisper.Whisper) => {
+      form = whisper;
       setTimeout(() => {
+        form.close((error => console.error(error)));
         resolve(true);
       }, 5000);
     });


### PR DESCRIPTION
This PR in the LDK simply adds a visual test for checkbox and radio whisper types to self-test-loop. Support for markdown is added via sidekick in another PR.