### PR TITLE
Run Webpack against node_modules

### DIFF
--- a/ldk/javascript/src/webpack/shared.ts
+++ b/ldk/javascript/src/webpack/shared.ts
@@ -67,11 +67,9 @@ export function buildWebpackConfig(
         {
           test: /\.ts$/,
           use: [{ ...baseBabelConfig }, { loader: 'ts-loader' }],
-          exclude: /node_modules/,
         },
         {
           test: /\.m?js$/,
-          exclude: /(node_modules|bower_components)/,
           use: { ...baseBabelConfig },
         },
       ],


### PR DESCRIPTION
This fixes an issue introduced in 3.0.1 where the Webpack config used for Loop compilation was not appropriately converting ES6 code from the LDK to ES5 for use by Helps. 

