### PR TITLE
HELPS-758: Run Webpack against node_modules and update LDK to 3.0.2

### DIFF
--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/ldk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "The Loop Development Kit for Olive Helps.",
   "author": "Olive",
   "copyright": "Copyright 2021 Olive",

--- a/ldk/javascript/src/webpack/shared.ts
+++ b/ldk/javascript/src/webpack/shared.ts
@@ -67,11 +67,9 @@ export function buildWebpackConfig(
         {
           test: /\.ts$/,
           use: [{ ...baseBabelConfig }, { loader: 'ts-loader' }],
-          exclude: /node_modules/,
         },
         {
           test: /\.m?js$/,
-          exclude: /(node_modules|bower_components)/,
           use: { ...baseBabelConfig },
         },
       ],


### PR DESCRIPTION
This fixes an issue introduced in 3.0.1 where the Webpack config used for Loop compilation was not appropriately converting ES6 code from the LDK to ES5 for use by Helps.