### PR TITLE
[SIDE-2544] Add Whisper Key properties

### DIFF
--- a/docs/src/markdown-pages/aptitudes/whisper.create.md
+++ b/docs/src/markdown-pages/aptitudes/whisper.create.md
@@ -30,7 +30,7 @@ The following component types are available:
 * Telephone - The text input field allows the user to provide a telephone number.
 * TextInput - The text input field allows the user to provide text information. The text can be pre-populated by the loop
 
-## Whisper Component State
+## Whisper Data Entry
 Provided on each newly created whisper is `componentState` property that is of `type StateMap = Map<string, string | boolean | number>`.
 
 When any of the following user editable components are assigned a **unique** `id` property, state will be tracked upon user interaction on `componentState`:
@@ -75,5 +75,16 @@ const myWhisper = await whisper.create({
 myWhisper.componentState.forEach((value: any, key: string) => console.log(key, value));
 ```
 
-### Component State Across Whisper Updates
+### Whisper Data Entry Across Whisper Updates
 If a whisper update is performed, all previously tracked component state will also persist. If new components are added to the update whisper, they will follow the rules for initial component state. If it is no longer desired to keep component state across a whisper update, then new component `id` properties should be assigned.
+
+## Component Keys
+
+Each component has an optional `key` property. The `key` property is used by our React front-end to retain the state of our presentational components across Whisper updates. If provided, keys must be unique across your component's siblings otherwise the Promise returned from `whisper.create` will reject with an error.
+
+You should provide keys for your components if you are updating Whispers and adding components or changing their state.
+
+You do not need to provide keys if:
+
+- You never update the Whisper.
+- You only add components to the end of the component list during your updates.

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
@@ -109,9 +109,8 @@ export const basicWhisperUpdate = (): Promise<boolean> =>
             type: WhisperComponentType.TextInput,
             label: 'Text Input',
             id: 'myTextInput1',
-            onChange: (error, param, onChangeWhisper) => {
-              console.info(logMap(onChangeWhisper.componentState));
-            },
+            key: 'textinput1',
+            onChange: (error, param, onChangeWhisper) => logMap(onChangeWhisper.componentState),
             tooltip: 'myTooltip',
           },
           {
@@ -123,16 +122,21 @@ export const basicWhisperUpdate = (): Promise<boolean> =>
             reject,
             [
               {
+                type: WhisperComponentType.Markdown,
+                body: 'MARKDOWN WARNING',
+                key: 'warning',
+              },
+              {
                 type: WhisperComponentType.TextInput,
                 label: 'Text Input 2',
                 id: 'myTextInput1',
-                onChange: (error, param, onChangeWhisper) => {
-                  console.info(logMap(onChangeWhisper.componentState));
-                },
+                key: 'textinput1',
+                // TODO: Figure out what state to persist, probably need to retain focus.
+                onChange: (error, param, onChangeWhisper) => logMap(onChangeWhisper.componentState),
                 tooltip: 'myTooltip',
               },
             ],
-            'Did the whisper update correctly? (state will persist)', // TODO: State persistence across update is an upcoming feature.
+            'Did the whisper update correctly? (state will persist)',
             'User selected update failed.',
           ),
         ],
@@ -151,6 +155,7 @@ export const updateCollapseState = (): Promise<boolean> =>
           type: WhisperComponentType.Checkbox,
           label: 'cb1',
           value: false,
+          key: 'c1',
           onChange: () => {
             // do nothing.
           },
@@ -159,6 +164,7 @@ export const updateCollapseState = (): Promise<boolean> =>
           type: WhisperComponentType.Checkbox,
           label: 'cb2',
           value: false,
+          key: 'c2',
           onChange: () => {
             // do nothing.
           },
@@ -170,6 +176,7 @@ export const updateCollapseState = (): Promise<boolean> =>
         children: [...checkboxes],
         label: 'first CollapseBox',
         open: false,
+        key: 'collapse',
       };
 
       whisper.create({
@@ -186,7 +193,16 @@ export const updateCollapseState = (): Promise<boolean> =>
           updateWithConfirmation(
             resolve,
             reject,
-            [collapseBox],
+            [
+              {
+                type: WhisperComponentType.Message,
+                header: 'New Message',
+              },
+              {
+                ...collapseBox,
+                open: true,
+              },
+            ],
             'Did the CollapseBox stay expanded?',
             'User selected update failed.',
           ),

--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -279,6 +279,7 @@ declare namespace OliveHelps {
   interface Component<T extends WhisperComponentType> {
     id?: string;
     type: T;
+    key?: string;
   }
 
   type WhisperHandler = (error: Error | undefined, whisper: Whisper) => void;

--- a/ldk/javascript/src/webpack/generate-banner.test.ts
+++ b/ldk/javascript/src/webpack/generate-banner.test.ts
@@ -39,7 +39,7 @@ describe('Generate Banner', () => {
   it('generates banner given valid LdkSettings', () => {
     const actual = getLoopMetadataContent(generateBanner(ldkSettings));
     const expected = {
-      oliveHelpsContractVersion: '0.1.1',
+      oliveHelpsContractVersion: '0.1.2',
       permissions: {
         clipboard: {},
         cursor: {},
@@ -73,7 +73,7 @@ describe('Generate Banner', () => {
     const actual = getLoopMetadataContent(generateBanner(ldkSettings));
 
     const expected = {
-      oliveHelpsContractVersion: '0.1.1',
+      oliveHelpsContractVersion: '0.1.2',
       permissions: {
         filesystem: { pathGlobs: [{ value: '/my/path' }] },
         network: { urlDomains: [{ value: '*.google.com' }] },
@@ -87,7 +87,7 @@ describe('Generate Banner', () => {
   it('adds oliveHelpsContractVersion', () => {
     const result = getLoopMetadataContent(generateBanner(ldkSettings));
 
-    expect(result.oliveHelpsContractVersion).toEqual('0.1.1');
+    expect(result.oliveHelpsContractVersion).toEqual('0.1.2');
   });
 
   it('throws exception when LDK permissions are not provided', () => {

--- a/ldk/javascript/src/webpack/generate-banner.ts
+++ b/ldk/javascript/src/webpack/generate-banner.ts
@@ -11,7 +11,7 @@ export function generateMetadata(ldkSettings: LdkSettings): string {
     throw new Error(permissionsErrorMessage);
   }
   const json = JSON.stringify({
-    oliveHelpsContractVersion: '0.1.1',
+    oliveHelpsContractVersion: '0.1.2',
     permissions: {
       clipboard: ldkSettings.ldk.permissions.clipboard || undefined,
       cursor: ldkSettings.ldk.permissions.cursor || undefined,

--- a/ldk/javascript/src/whisper/mapper.ts
+++ b/ldk/javascript/src/whisper/mapper.ts
@@ -21,6 +21,7 @@ export function mapToInternalChildComponent(
           id: component.id,
           alignment: 'justifyContent' in component ? component.justifyContent : component.alignment,
           direction: component.direction,
+          key: component.key,
           children: component.children.map((childComponent) =>
             mapToInternalChildComponent(childComponent, stateMap),
           ),
@@ -34,6 +35,7 @@ export function mapToInternalChildComponent(
         id: component.id,
         alignment: 'justifyContent' in component ? component.justifyContent : component.alignment,
         direction: component.direction,
+        key: component.key,
         children: component.children.map((childComponent) =>
           mapToInternalChildComponent(childComponent, stateMap),
         ),
@@ -185,6 +187,7 @@ export function mapToInternalComponent(
         return {
           label: component.label,
           open: component.open,
+          key: component.key,
           children: component.children.map((childComponent) =>
             mapToInternalChildComponent(childComponent, stateMap),
           ),
@@ -198,6 +201,7 @@ export function mapToInternalComponent(
         id: component.id,
         label: component.label,
         open: component.open,
+        key: component.key,
         children: component.children.map((childComponent) =>
           mapToInternalChildComponent(childComponent, stateMap),
         ),

--- a/ldk/javascript/src/whisper/mapper.ts
+++ b/ldk/javascript/src/whisper/mapper.ts
@@ -8,6 +8,22 @@ import {
   WhisperComponentType,
 } from './types';
 
+function throwForDuplicateKeys<T extends { key?: string }>(components: T[]): T[] {
+  const keySet = new Set<string>();
+  components.forEach((item) => {
+    if (item.key === undefined) {
+      return;
+    }
+    if (keySet.has(item.key)) {
+      throw new Error(
+        `Duplicate Key ${item.key} encountered, provided keys must be unique among its siblings`,
+      );
+    }
+    keySet.add(item.key);
+  });
+  return components;
+}
+
 export function mapToInternalChildComponent(
   component: BoxChildComponent,
   stateMap: StateMap,
@@ -22,8 +38,10 @@ export function mapToInternalChildComponent(
           alignment: 'justifyContent' in component ? component.justifyContent : component.alignment,
           direction: component.direction,
           key: component.key,
-          children: component.children.map((childComponent) =>
-            mapToInternalChildComponent(childComponent, stateMap),
+          children: throwForDuplicateKeys(
+            component.children.map((childComponent) =>
+              mapToInternalChildComponent(childComponent, stateMap),
+            ),
           ),
           type: WhisperComponentType.Box,
           onClick: (error, whisper) => {
@@ -36,8 +54,10 @@ export function mapToInternalChildComponent(
         alignment: 'justifyContent' in component ? component.justifyContent : component.alignment,
         direction: component.direction,
         key: component.key,
-        children: component.children.map((childComponent) =>
-          mapToInternalChildComponent(childComponent, stateMap),
+        children: throwForDuplicateKeys(
+          component.children.map((childComponent) =>
+            mapToInternalChildComponent(childComponent, stateMap),
+          ),
         ),
         type: WhisperComponentType.Box,
       };
@@ -188,8 +208,10 @@ export function mapToInternalComponent(
           label: component.label,
           open: component.open,
           key: component.key,
-          children: component.children.map((childComponent) =>
-            mapToInternalChildComponent(childComponent, stateMap),
+          children: throwForDuplicateKeys(
+            component.children.map((childComponent) =>
+              mapToInternalChildComponent(childComponent, stateMap),
+            ),
           ),
           type: WhisperComponentType.CollapseBox,
           onClick: (error: Error, param: boolean, whisper: OliveHelps.Whisper) => {
@@ -202,8 +224,10 @@ export function mapToInternalComponent(
         label: component.label,
         open: component.open,
         key: component.key,
-        children: component.children.map((childComponent) =>
-          mapToInternalChildComponent(childComponent, stateMap),
+        children: throwForDuplicateKeys(
+          component.children.map((childComponent) =>
+            mapToInternalChildComponent(childComponent, stateMap),
+          ),
         ),
         type: WhisperComponentType.CollapseBox,
       };
@@ -228,14 +252,14 @@ export function mapToInternalWhisper(
     ? {
         label: whisper.label,
         onClose: whisper.onClose,
-        components: whisper.components.map((component) =>
-          mapToInternalComponent(component, stateMap),
+        components: throwForDuplicateKeys(
+          whisper.components.map((component) => mapToInternalComponent(component, stateMap)),
         ),
       }
     : {
         label: whisper.label,
-        components: whisper.components.map((component) =>
-          mapToInternalComponent(component, stateMap),
+        components: throwForDuplicateKeys(
+          whisper.components.map((component) => mapToInternalComponent(component, stateMap)),
         ),
       };
 }

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -121,6 +121,10 @@ export type WhisperHandlerWithParam<T> = (
 export interface WhisperComponent<T extends WhisperComponentType> {
   id?: string;
   type: T;
+  /**
+   * The key is used to maintain the object state. The component's key must be unique among its sibling components.
+   */
+  key?: string;
 }
 
 export type Button = WhisperComponent<WhisperComponentType.Button> & {

--- a/ldk/javascript/src/whisper/whisper.test.ts
+++ b/ldk/javascript/src/whisper/whisper.test.ts
@@ -72,7 +72,7 @@ describe('Whisper', () => {
         componentState: expect.any(Map),
       });
     });
-    it('Throws if it encounters a duplicate key', async() => {
+    it('Throws if it encounters a duplicate key', async () => {
       const expectedClose = jest.fn();
       const newWhisper: whisper.NewWhisper = {
         components: [
@@ -95,7 +95,6 @@ describe('Whisper', () => {
 
       expect(() => create(newWhisper)).rejects.toEqual(expect.any(Error));
       expect(oliveHelps.whisper.create).not.toHaveBeenCalled();
-
     });
 
     it('wraps calls to update', async () => {

--- a/ldk/javascript/src/whisper/whisper.test.ts
+++ b/ldk/javascript/src/whisper/whisper.test.ts
@@ -72,6 +72,31 @@ describe('Whisper', () => {
         componentState: expect.any(Map),
       });
     });
+    it('Throws if it encounters a duplicate key', async() => {
+      const expectedClose = jest.fn();
+      const newWhisper: whisper.NewWhisper = {
+        components: [
+          {
+            body: 'Test',
+            id: '1',
+            type: whisper.WhisperComponentType.Markdown,
+            key: 'a',
+          },
+          {
+            body: 'Test',
+            id: '1',
+            type: whisper.WhisperComponentType.Markdown,
+            key: 'a',
+          },
+        ],
+        label: 'Test',
+        onClose: expectedClose,
+      };
+
+      expect(() => create(newWhisper)).rejects.toEqual(expect.any(Error));
+      expect(oliveHelps.whisper.create).not.toHaveBeenCalled();
+
+    });
 
     it('wraps calls to update', async () => {
       const newWhisper: whisper.NewWhisper = {


### PR DESCRIPTION
This PR:

- Adds the `key` property to all Whispers for both the internal and external Whisper types.
- Updates the self test loop to test for whisper update changes.
- Adds documentation appropriate for the above.
- Increments the OH contract version.