### PR TITLE
[HELPS-775] Update documentation about relative file paths

### DIFF
--- a/docs/src/markdown-pages/aptitudes/filesystem.md
+++ b/docs/src/markdown-pages/aptitudes/filesystem.md
@@ -8,36 +8,65 @@ Provides read and write access to the filesystem, enabling Loop Authors to read 
 
 [Permissions must be declared](https://github.com/open-olive/loop-development-kit/tree/main/ldk/javascript#loop-permissions) for a Loop to use the Filesystem Aptitude.
 
-The filesystem permissions object must be populated with the locations you want to access in the following format:
+### Permissions
 
+The filesystem permissions object must be populated with the absolute paths of the files and directories you want to access in the following format:
+
+```json5
+{
+  "ldk": {
+    "permissions": {
+      "filesystem": {
+        "pathGlobs": [
+          {
+            // Provides access to all files in the /tmp directory that have a .txt extension.
+            "value": "/tmp/*.txt"
+          },
+          {
+            // Provides access to all directories and files under the /tmp directory.
+            "value": "/tmp/**"
+          },
+          {
+            // Provides access to all files with .txt extensions in the /tmp directory or any of its subdirectories.
+            "value": "/tmp/**/*.txt"
+          },
+          {
+            // Provides access to all files with .txt extensions in any subdirectory of /tmp.
+            "value": "/tmp/*/*.txt"
+          }
+        ]
+      }
+    }
+  }
+}
 ```
-ldk:
- permissions:
-   filesystem:
-     pathGlobs:
-       -  value: '/tmp/*.txt'
+
+Attempts to access a file or directory you have not added permissions for will fail.
+
+### Working Directory
+
+Each Loop gets a dedicated working directory that it can use to store files that don't need to be placed in a specific location. 
+
+Other Loops will not be able to access this directory.
+
+Each Loop with filesystem permissions requested will automatically have access to this directory, its subdirectories, and any files within. If you only need access to the working directory, provide an empty `filesystem` permissions object:
+
+```json
+{
+  "ldk": {
+    "permissions": {
+      "filesystem": {}
+    }
+  }
+}
 ```
 
-### Filesystem Notes
+To access a file or directory inside the working directory, provide a relative path:
+```js
+const csvContents = await ldk.filesystem.readFile('./my-file.csv');
+```
 
-When your Loop is executing within Olive Helps, it will generate its own unique "work directory" upon first run. This work directory is separate from every other Loop, and is empty at start.
-
-#### Other rules pertaining to Loop's unique "work directory":
-
-- Loops can do whatever they want in this directory, but they cannot destroy their "work directory" reference. For example, `filesystem.remove("./")` is **invalid**.
-- If your Loop accesses a relative path (example: `./some-file.txt`), you do not have to specify that path in your `package.json` permission list as a `pathGlob`.
+- Loops can do whatever they want in this directory, but they cannot destroy their working directory. For example `filesystem.remove("./")` will fail.
 - All relative paths are automatically allowed as long as they actually resolve to something in the Loop's "work directory".
-- Filepaths which refer to parent directories (example: `../`) will be securely handled/processed.
-- The Loop's "work directory" is named as the Loop's `AppId` - anything in the directory should persist across Loop updates.
-
-#### Working with files outside of Loop's unique "work directory":
-
-- Files can be written outside of each Loop's "work directory", if an absolute path is provided. In this filepath scheme are **persisted across Loop fresh installs**. Permissions must be declared for the Loop specifying absolute file paths. For example, `/some/path/something.txt` can be written by specifying the following permissions:
-```
-"filesystem": {
-  "pathGlobs": [
-    { "value": "/some/path/something.txt" }
-  ]
-},
-...
-```
+- Fil epaths which refer to parent directories (example: `../`) requires permissions to be specifically provided as normal.
+- Shutting down or updating a Loop does not delete the working directory or its contents.

--- a/ldk/javascript/readme.md
+++ b/ldk/javascript/readme.md
@@ -129,7 +129,7 @@ Examples
 <br>
 
 #### Filesystem Permission:
-Any filesystem path. Supports path wildcards.
+Any filesystem path. Supports path wildcards. All filesystem permissions include access to the Loop's working folder by default.
 ```json
 "ldk": {
   "filesystem": {
@@ -146,7 +146,14 @@ Examples
 |-----------|
 | "/some/path/something.txt" |
 | "/Users/ldkuser/Desktop/*" |
-<br>
+
+If your Loop only needs access to the Loop's working folder, provide an empty object:
+
+```json
+"ldk": {
+  "filesystem": {}
+}
+```
 
 #### Aptitude Permission:
 An Aptitude Name.


### PR DESCRIPTION
This PR:

- Adds that permissions to the working directory are automatically granted and only an empty object needs to be provided.
- Reworks some of the aptitude documentation and adds some path glob examples.