### PR TITLE
HELPS-788: Omit unnecessary claims from User Aptitude JWT

### DIFF
--- a/docs/src/markdown-pages/aptitudes/user.createJWT.md
+++ b/docs/src/markdown-pages/aptitudes/user.createJWT.md
@@ -2,7 +2,7 @@
 name: "JWT"
 links_js: "jwt"
 ---
-Receive a [JWT](https://jwt.io) identifying the currently logged in Olive Helps user.
+Receive a [JWT](https://jwt.io) identifying the currently logged in Olive Helps user. The email claim is only returned when the includeEmail parameter is true.
 
 ### JWT Claims
 The claims in the JWT are as follows:
@@ -14,7 +14,7 @@ Standard Claims:
 
 Additional Claims:
 * `azp` (Authorized Party): contains the LoopID of the Loop which requested the JWT.
-* `email`: contains the email address of the current Olive Helps user.
+* `email`: contains the email address of the current Olive Helps user. This claim is not included by default, but can be requested by passing true as the value of the includeEmail parameter.
 
 
 ### JWT Signing

--- a/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
@@ -5,5 +5,16 @@ import * as userTests from '../tests/user';
 
 export const userTestGroup = (): TestGroup =>
   new TestGroup('User Aptitude', [
-    new LoopTest('User Aptitude - JWT', userTests.testJwt, 10000, 'No action required'),
+    new LoopTest(
+      'User Aptitude - JWT - No Email Claim',
+      userTests.testJwt,
+      10000,
+      'No action required',
+    ),
+    new LoopTest(
+      'User Aptitude - JWT - Email Claim',
+      userTests.testJwtIncludeEmail,
+      10000,
+      'No action required',
+    ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
@@ -1,10 +1,64 @@
-import { user } from '@oliveai/ldk';
+import { user, clipboard, whisper } from '@oliveai/ldk';
 
 export const testJwt = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
     user.jwt().then((token) => {
       if (token) {
-        console.debug('jwt', token);
+        whisper.create({
+          label: 'User Aptitude JWT - No Email',
+          components: [
+            {
+              type: whisper.WhisperComponentType.Markdown,
+              body:
+                'You can paste the token into jwt.io to check the claims. This token **should not** have an email claim.',
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to copy the JWT to your clipboard.',
+              onClick: async () => {
+                await clipboard.write(token);
+              },
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to open jwt.io',
+              href: 'https://jwt.io',
+            },
+          ],
+        });
+        resolve(true);
+      } else {
+        reject(new Error('JWT should not have been empty'));
+      }
+    });
+  });
+
+export const testJwtIncludeEmail = (): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    user.jwt({ includeEmail: true }).then((token) => {
+      if (token) {
+        whisper.create({
+          label: 'User Aptitude JWT - Include Email',
+          components: [
+            {
+              type: whisper.WhisperComponentType.Markdown,
+              body:
+                'You can paste the token into jwt.io to check the claims. This token **should** have an email claim.',
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to copy the JWT to your clipboard.',
+              onClick: async () => {
+                await clipboard.write(token);
+              },
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to open jwt.io',
+              href: 'https://jwt.io',
+            },
+          ],
+        });
         resolve(true);
       } else {
         reject(new Error('JWT should not have been empty'));

--- a/ldk/javascript/src/promisify.ts
+++ b/ldk/javascript/src/promisify.ts
@@ -63,6 +63,19 @@ export function promisify<T>(arg: OliveHelps.Readable<T>): Promise<T> {
   });
 }
 
+export function promisifyWithParamAfterCallback<TParam, TOut>(
+  param: TParam,
+  arg: OliveHelps.ReadableWithParamAfterCallback<TOut, TParam>,
+): Promise<TOut> {
+  return new Promise((resolve, reject) => {
+    try {
+      arg(promiseResolver(resolve, reject), param);
+    } catch (e) {
+      handleCaughtError(reject, e);
+    }
+  });
+}
+
 export function promisifyWithParam<TParam, TOut>(
   param: TParam,
   arg: OliveHelps.ReadableWithParam<TParam, TOut>,

--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -30,6 +30,10 @@ declare namespace OliveHelps {
   type Readable<T> = (callback: Callback<T>) => void;
 
   type ReadableWithParam<TParam, TOut> = (param: TParam, callback: Callback<TOut>) => void;
+  type ReadableWithParamAfterCallback<TOut, TParam> = (
+    callback: Callback<TOut>,
+    param: TParam,
+  ) => void;
 
   type ReadableWithTwoParams<TParam1, TParam2, TOut> = (
     param: TParam1,
@@ -53,8 +57,12 @@ declare namespace OliveHelps {
     returnCb: ReturnCallback,
   ) => void;
 
+  //-- User
+  interface JWTConfig {
+    includeEmail?: boolean;
+  }
   interface User {
-    jwt: Readable<string>;
+    jwt: ReadableWithParamAfterCallback<string, JWTConfig>;
   }
 
   //-- Window

--- a/ldk/javascript/src/user/index.ts
+++ b/ldk/javascript/src/user/index.ts
@@ -1,17 +1,21 @@
 /**
  * The User aptitude gives access to Olive Helps user related information
  */
-import { promisify } from '../promisify';
+import { promisifyWithParamAfterCallback } from '../promisify';
 
+export interface JWTConfig {
+  includeEmail?: boolean;
+}
 export interface User {
   /**
-   * Returns a JWT with the current username in the subject field
+   * Returns a JWT identifying the current OliveHelps user.
    *
+   * @param includeEmail if true, the user's email address will be included in an optional email claim.
    * @returns JWT with the current username in the subject field.
    */
-  jwt(): Promise<string>;
+  jwt(jwtConfig?: JWTConfig): Promise<string>;
 }
 
-export function jwt(): Promise<string> {
-  return promisify(oliveHelps.user.jwt);
+export function jwt(jwtConfig: JWTConfig = {}): Promise<string> {
+  return promisifyWithParamAfterCallback(jwtConfig, oliveHelps.user.jwt);
 }

--- a/ldk/javascript/src/user/user.test.ts
+++ b/ldk/javascript/src/user/user.test.ts
@@ -9,13 +9,25 @@ describe('User', () => {
   });
 
   describe('jwt', () => {
-    it('returns a promise with the token', () => {
+    it('returns a promise with the token when jwtConfig is unset', () => {
       const jwt = 'jwt';
       mocked(oliveHelps.user.jwt).mockImplementation((callback) => callback(undefined, jwt));
 
       const actual = user.jwt();
 
-      expect(oliveHelps.user.jwt).toHaveBeenCalledWith(expect.any(Function));
+      expect(oliveHelps.user.jwt).toHaveBeenCalledWith(expect.any(Function), {});
+      return expect(actual).resolves.toBe(jwt);
+    });
+
+    it('returns a promise with the token when jwtConfig is present', () => {
+      const jwt = 'jwt';
+      mocked(oliveHelps.user.jwt).mockImplementation((callback) => callback(undefined, jwt));
+
+      const actual = user.jwt({ includeEmail: true });
+
+      expect(oliveHelps.user.jwt).toHaveBeenCalledWith(expect.any(Function), {
+        includeEmail: true,
+      });
       return expect(actual).resolves.toBe(jwt);
     });
 


### PR DESCRIPTION
This commit adds an optional includeEmail parameter to the User Aptitude
jwt function. When this parameter is set to true, the JWT will include
the current user's email address. When the parameter is unset, or false,
the email address will not be included in the JWT's claims, limiting
potential PII exposure.