### PR TITLE
Helps 898 http request blocks

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/network-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/network-group.ts
@@ -24,6 +24,12 @@ export const networkTestGroup = (): TestGroup =>
       'Custom timeout should pass',
     ),
     new LoopTest(
+      'Network Aptitude - HTTP block test',
+      networkTests.testHttpRequestBlock,
+      5000,
+      'HTTP call should not block',
+    ),
+    new LoopTest(
       'Network Aptitude - WebSocket test',
       networkTests.testWebsocketConnection,
       20000,

--- a/ldk/javascript/examples/self-test-loop/src/config/system-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/system-group.ts
@@ -7,7 +7,7 @@ export const systemTestGroup = (): TestGroup =>
   new TestGroup('System Aptitude', [
     new LoopTest(
       'System Aptitude - Operating System',
-      systemTests.operatingSystemTest,
+      systemTests.testOperatingSystem,
       5000,
       `Checking the host's OS...`,
     ),

--- a/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
@@ -74,7 +74,7 @@ export const testHttpRequestTimeout = (): Promise<boolean> =>
 export const testHttpRequestBlock = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
     try {
-      const url = 'https://httpstat.us/200?sleep=5000';
+      const url = 'https://httpstat.us/200?sleep=4000';
       setTimeout(() => {
         console.debug(`Http request blocked which caused a timeout`);
         reject(new Error(`Test didn't resolved in the appropriate time frame`));
@@ -86,9 +86,12 @@ export const testHttpRequestBlock = (): Promise<boolean> =>
           timeoutMs: 5000,
         })
         .then(() => {
-          console.debug(`Http request didn't blocked`);
-          resolve(true);
+          console.debug(`Should not get here. Test should timeout or resolve before getting a response`);
+          reject(new Error());
         });
+        console.debug(`Http request didn't blocked`);
+        resolve(true);
+
     } catch (e) {
       console.error(e);
       reject(e);

--- a/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
@@ -86,12 +86,13 @@ export const testHttpRequestBlock = (): Promise<boolean> =>
           timeoutMs: 5000,
         })
         .then(() => {
-          console.debug(`Should not get here. Test should timeout or resolve before getting a response`);
+          console.debug(
+            `Should not get here. Test should timeout or resolve before getting a response`,
+          );
           reject(new Error());
         });
-        console.debug(`Http request didn't blocked`);
-        resolve(true);
-
+      console.debug(`Http request didn't blocked`);
+      resolve(true);
     } catch (e) {
       console.error(e);
       reject(e);

--- a/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/network/index.ts
@@ -71,6 +71,30 @@ export const testHttpRequestTimeout = (): Promise<boolean> =>
     }
   });
 
+export const testHttpRequestBlock = (): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    try {
+      const url = 'https://httpstat.us/200?sleep=5000';
+      setTimeout(() => {
+        console.debug(`Http request blocked which caused a timeout`);
+        reject(new Error(`Test didn't resolved in the appropriate time frame`));
+      }, 2000);
+      network
+        .httpRequest({
+          url,
+          method: 'GET',
+          timeoutMs: 5000,
+        })
+        .then(() => {
+          console.debug(`Http request didn't blocked`);
+          resolve(true);
+        });
+    } catch (e) {
+      console.error(e);
+      reject(e);
+    }
+  });
+
 export const testWebsocketConnection = (): Promise<boolean> =>
   new Promise(async (resolve, reject) => {
     const url = 'wss://html5rocks.websocket.org/echo';

--- a/ldk/javascript/examples/self-test-loop/src/tests/system/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/system/index.ts
@@ -1,8 +1,6 @@
-import { system, whisper } from '@oliveai/ldk';
+import { system } from '@oliveai/ldk';
 
-import { Cancellable } from '@oliveai/ldk/dist/cancellable';
-
-export const operatingSystemTest = (): Promise<boolean> =>
+export const testOperatingSystem = (): Promise<boolean> =>
   new Promise((resolve, reject) => {
     system
       .operatingSystem()


### PR DESCRIPTION
Adding selfTestLoop to test httpRequest blocking behavior. The test will fail if httpRequest block the thread. This issue is resolved in the sidekick.