### PR TITLE
[WIP] HELPS-93: Add Guide for  Loop Monetization

### DIFF
--- a/docs/src/markdown-pages/guides/monetizing-your-loop.md
+++ b/docs/src/markdown-pages/guides/monetizing-your-loop.md
@@ -1,0 +1,41 @@
+---
+slug: 'guides/monetizing-your-loop'
+title: 'Monetizing Your Loop'
+description: 'Learn how to monetize your Loop with Pi.'
+---
+# Monetizing Your Loop
+
+## What is Pi?
+
+Perpetual Impact (Pi) is the currency of Olive. It’s how we create a lasting relationship of value with our customers. Olive Helps users and organizations can purchase Pi with USD at an exchange rate of 3 Pi for 1 USD. Once they have a Pi balance, they’ll use this currency to interact with the Loop Library and subscribe to Paid Loops.
+
+## Earning Pi Revenue
+
+When a user or organization subscribes to a Loop, the Loop Author will receive 85% of all Pi revenue earned. Olive will retain 15% to cover hosting fees, operational costs, and fuel platform reinvestment.  As an Author, you will initially receive this subscription revenue in Pi, which you can then “cash out” in the form of USD after the minimum payout balance of 300Pi (100 USD) has been reached.
+
+## Free vs Paid Loops
+
+Before submitting your Loop for approval, you’ll first want to determine whether the Loop will be Free or Paid. Free Loops will be available for users to install at no cost, while Paid Loops will require a user to purchase a monthly subscription.
+
+By developing on the Olive Helps platform, Loop Authors have the opportunity to earn revenue whenever a user subscribes to their Loop.
+
+## Choosing a Subscription Model
+
+If you’ve designated a Loop as Paid, you’ll need to choose from one of the available subscription models.
+
+Per User subscription models require each user accessing the Loop to have a monthly subscription. This pricing model is ideal for Loops that are targeting a broader audience of users across a variety of organizations.
+Per Organization subscription models only require one organization-wide monthly subscription for an unlimited number of users to access the Loop. This pricing model offers organizations of all sizes the convenience of a defined cost without the need to manage individual subscriptions as their usage requirements change.
+
+We recognize that Loop Authors may be interested in pricing models not listed above. Our team will be exploring additional pricing options in future releases of Olive Helps to provide greater flexibility. If you're interested in suggesting a Loop pricing model, you can do so through our [Feedback Form](https://docs.google.com/forms/d/e/1FAIpQLSfuC9eaf9R6Fns6wd_mgCgicvsCreaXudNPWFDtTxO0hfPNOg/viewform).
+
+## Pricing Your Loop
+
+Once you’ve chosen a subscription model, you’re finally ready to put a price tag on your Loop. Users making purchases in the Loop Library will view the monthly price in Pi before confirming their subscription. Consider the following questions when finalizing your Loop’s price:
+
+* Who is the target audience for my Loop?
+* How frequently do I expect to see this Loop used once purchased?
+* Who are my competitors? Is my Loop’s pricing competitive with the market?
+* How much value could my Loop bring to an individual user and organization?
+* What are my existing costs for supporting and maintaining my Loop?
+* How much will be added or changed in future updates to my Loop?
+* Have I performed financial modeling to compare pricing options?


### PR DESCRIPTION
This PR adds a guide to the Dev Hub describing how Loop Authors can monetize their Loops. 

This will not be merged until Transactions are released. 