### PR TITLE
[HELPS-854] Update Dropzone event types, support setting/clearing values.

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
@@ -125,4 +125,5 @@ export const whisperTestGroup = (): TestGroup =>
       10000,
       'Pick date and time values',
     ),
+    new LoopTest('Whisper Aptitude - Dropzone', whisperTests.testDropzone, 30000, 'Select files'),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/selfTest.ts
+++ b/ldk/javascript/examples/self-test-loop/src/selfTest.ts
@@ -1,6 +1,6 @@
 import { keyboard } from '@oliveai/ldk';
 import { emitTestWhisper } from './testingFixtures/testWhisper';
-import WhisperCloser from './testingFixtures/WhisperCloser';
+import WhisperCloser from './testingFixtures/whisperCloser';
 
 export default class SelfTestLoop {
   async start(): Promise<void> {

--- a/ldk/javascript/examples/self-test-loop/src/testingFixtures/testWhisper.ts
+++ b/ldk/javascript/examples/self-test-loop/src/testingFixtures/testWhisper.ts
@@ -14,7 +14,7 @@ import TestSuite from './testSuite';
 import { LoopTest } from './loopTest';
 import { testConfig } from '../config';
 import TestGroup from './testGroup';
-import WhisperCloser from './WhisperCloser';
+import WhisperCloser from './whisperCloser';
 
 const emitGroupDoneWhisper = async (group: TestGroup) => {
   const form = await whisper.create({

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-async-promise-executor */
 import { clipboard, network, whisper } from '@oliveai/ldk';
 import {
-  Button,
   ButtonSize,
   ButtonStyle,
   Component,
@@ -278,32 +277,17 @@ export const testDropzone = async (): Promise<boolean> => {
     .join('\n\n');
 
   function createAcceptButtons(): {
-    acceptButton: Button;
-    rejectButton: Button;
+    component: Component;
     acceptResult: Promise<boolean>;
   } {
-    const acceptButton: whisper.Button = {
-      type: WhisperComponentType.Button,
-      label: 'Yes',
-      onClick: () => {},
-    };
-    const rejectButton: whisper.Button = {
-      type: WhisperComponentType.Button,
-      label: 'No',
-      onClick: () => {},
-    };
+    let resolveHandler;
+    let rejectHandler;
     const acceptResult = new Promise<boolean>((resolve, reject) => {
-      rejectButton.onClick = (error) => {
-        reject(error);
-      };
-      acceptButton.onClick = (error) => {
-        if (error) {
-          reject(error);
-        }
-        resolve(true);
-      };
+      resolveHandler = resolve;
+      rejectHandler = reject;
     });
-    return { acceptButton, rejectButton, acceptResult };
+    const component = resolveRejectButtons(resolveHandler, rejectHandler);
+    return { component, acceptResult };
   }
 
   const acceptFileData = createAcceptButtons();
@@ -314,8 +298,7 @@ export const testDropzone = async (): Promise<boolean> => {
         body: `Are these the files you selected?\n\n${fileData}`,
       },
       dropZone,
-      acceptFileData.acceptButton,
-      acceptFileData.rejectButton,
+      acceptFileData.component,
     ],
   });
   await acceptFileData.acceptResult;
@@ -325,8 +308,7 @@ export const testDropzone = async (): Promise<boolean> => {
     components: [
       { type: WhisperComponentType.Markdown, body: 'Are the files gone now?' },
       { ...dropZone, value: [] },
-      filesWereCleared.acceptButton,
-      filesWereCleared.rejectButton,
+      filesWereCleared.component,
     ],
   });
   return filesWereCleared.acceptResult;

--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -373,7 +373,7 @@ declare namespace OliveHelps {
     label: string;
     limit?: number;
     noun?: string;
-    onDrop: WhisperHandlerWithParam<File>;
+    onDrop: WhisperHandlerWithParam<File[]>;
     value?: File[];
     tooltip?: string;
     validationError?: string;

--- a/ldk/javascript/src/types/oliveHelps/index.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/index.d.ts
@@ -373,7 +373,8 @@ declare namespace OliveHelps {
     label: string;
     limit?: number;
     noun?: string;
-    onDrop: WhisperHandlerWithParam<FileDropEvent>;
+    onDrop: WhisperHandlerWithParam<File>;
+    value?: File[];
     tooltip?: string;
     validationError?: string;
   };
@@ -501,8 +502,8 @@ declare namespace OliveHelps {
     create: ReadableWithParam<NewWhisper, Whisper>;
   }
 
-  interface FileDropEvent {
-    // TODO: Update in HELPS-854.
+  interface File {
     path: string;
+    size: number;
   }
 }

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -242,7 +242,7 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
   label: string;
   limit?: number;
   noun?: string;
-  onDrop: WhisperHandlerWithParam<File>;
+  onDrop: WhisperHandlerWithParam<File[]>;
   tooltip?: string;
   validationError?: string;
   value?: File[];

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -242,9 +242,10 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
   label: string;
   limit?: number;
   noun?: string;
-  onDrop: WhisperHandlerWithParam<FileDropEvent>;
+  onDrop: WhisperHandlerWithParam<File>;
   tooltip?: string;
   validationError?: string;
+  value?: File[];
 };
 
 export type Divider = WhisperComponent<WhisperComponentType.Divider>;
@@ -310,7 +311,7 @@ export interface UpdateWhisper {
   components: Array<Component>;
 }
 
-export interface FileDropEvent {
-  // TODO: Replace type in HELPS-854
+export interface File {
   path: string;
+  size: number;
 }


### PR DESCRIPTION
This PR updates the types for the onDrop callbacks, and allows Loop Authors to clear and/or re-arrange files from the selected list.