### PR TITLE
HELPS-829: Enable per environment LDK permissions

### DIFF
--- a/docs/src/markdown-pages/guides/permissions-configuration.md
+++ b/docs/src/markdown-pages/guides/permissions-configuration.md
@@ -12,7 +12,7 @@ These configuration files should be named according to this pattern: `ldk-config
 
 Per-environment configs can be activated by setting the `LDK_CONFIG` environment variable when running the Loop transpilation process. For example, running `LDK_CONFIG=dev npm run build` will load the configuration in `ldk-config.dev.json`.
 
-The permissions you declare in the `ldk` configuration section of your Loop's `package.json` are considered the "base" permissions config. For Aptitudes which require specific configuration (namely, the Network and Filesystem Aptitudes), any configuration in the environment specific config file will **replace** any values for these permissions in the base configuration. Running the build with no value for `LDK_CONFIG` set will result in only the base configuration being applied.
+The permissions you declare in the `ldk` configuration section of your Loop's `package.json` are considered the "base" permissions config. For Aptitudes which require specific configuration (namely, the Network and Filesystem Aptitudes), any configuration in the environment specific config file will **override** any values for these permissions in the base configuration. Running the build with no value for `LDK_CONFIG` set will result in only the base configuration being applied.
 
 ## Example
 As an example of this feature, consider the following two configurations:

--- a/docs/src/markdown-pages/guides/permissions-configuration.md
+++ b/docs/src/markdown-pages/guides/permissions-configuration.md
@@ -1,0 +1,53 @@
+---
+slug: 'guides/permissions-configuration'
+title: 'Configure Loop Permissions'
+description: "Learn how to set up Loop permissions"
+---
+
+# Permission Configuration
+
+If your Loop requires different permissions for different development environments, you can create special configuration files which can be loaded when running your Loop build.
+
+These configuration files should be named according to this pattern: `ldk-config.env.json`, where `env` can any string that indicates the name of a development environment. For example: `ldk-config.dev.json` or `ldk-config.qa.json`.
+
+Per-environment configs can be activated by setting the `LDK_CONFIG` environment variable when running the Loop transpilation process. For example, running `LDK_CONFIG=dev npm run build` will load the configuration in `ldk-config.dev.json`.
+
+The permissions you declare in the `ldk` configuration section of your Loop's `package.json` are considered the "base" permissions config. For Aptitudes which require specific configuration (namely, the Network and Filesystem Aptitudes), any configuration in the environment specific config file will **replace** any values for these permissions in the base configuration. Running the build with no value for `LDK_CONFIG` set will result in only the base configuration being applied.
+
+## Example
+As an example of this feature, consider the following two configurations:
+
+`package.json`
+```
+ "ldk": {
+    "permissions": {
+      "network": {
+          "urlDomains": [
+              { "value": "example.com" }
+          ]},
+      "whisper": {},
+      "clipboard": {}
+    }
+  }
+```
+
+`ldk-config.dev.json`
+```
+ "ldk": {
+    "permissions": {
+      "network": {
+          "urlDomains": [
+              { "value": "example-dev.com" }
+          ]
+      }
+    }
+}
+```
+
+The `package.json` represents the 'base' configuration, while `ldk-config.dev.json` overrides the configuration of the Network aptitude permissions.
+
+In this example, if the Loop is built with no `LDK_CONFIG` specified, the base configuration will be used. The Network Aptitude will have permission to make requests to `example.com`.
+
+If, instead, `LDK_CONFIG` is set to `dev`, the dev configuration will be loaded. In this case, the Network Aptitude will have permission to make requests to `example-dev.com` (and _not_ `example.com`).
+
+In either case, since the Whisper and Clipboard Aptitude permissions are granted in the base configuration, those permissions will be present in both the dev and base configurations.

--- a/ldk/javascript/readme.md
+++ b/ldk/javascript/readme.md
@@ -84,6 +84,8 @@ In order to ensure your Loop is executing in a secure manner, you must declare w
 
 Permissions are declared inside of the Loop `package.json` root within a `ldk/permissions` json object.
 
+The included LDK Webpack configuration allows Loop authors to configure alternate permissions for different development environments. See the [Permissions Configuration guide](https://oliveai.dev/guides/permissions-configuration) on the Olive Helps Developer Hub for more information.
+
 ```json
 "ldk": {
   "permissions": {
@@ -169,6 +171,8 @@ An Aptitude Name.
 "process"  | "ui" | "user"
 "vault" | "whisper" | "window"
 <br>
+
+
 
 ## Loop Examples
 Examples are provided in the `ldk/javascript/examples/` directory. These examples include more information about creating and building Loops.

--- a/ldk/javascript/src/webpack/config.ts
+++ b/ldk/javascript/src/webpack/config.ts
@@ -2,12 +2,9 @@ import * as webpack from 'webpack';
 import * as path from 'path';
 import { LdkSettings } from './ldk-settings';
 import { buildBabelConfig, buildOptimization, buildWebpackConfig } from './shared';
+import { generateLdkSettings } from './generate-ldk-settings';
 
-// Need to dynamically refer to Loop's package.json
-// Suppressing rule as we intentionally want a dynamic require.
-// eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require
-const ldkSettings: LdkSettings = require(path.join(process.cwd(), '/package.json'));
-
+const ldkSettings: LdkSettings = generateLdkSettings();
 const baseBabelConfig: webpack.RuleSetRule = buildBabelConfig(false);
 const optimization = buildOptimization(true);
 const buildPath = path.join(process.cwd(), 'dist');

--- a/ldk/javascript/src/webpack/generate-ldk-settings.test.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.test.ts
@@ -62,7 +62,7 @@ describe('Merge LDK Settings', () => {
     expect(mergedSettings).toEqual(expectedSettings);
   });
 
-  it('keys present in the base config exist in merged output', () => {
+  it('preserves keys from base config in merged output', () => {
     // Have to force any type here to allow mergeLdkSettings to accept this shape
     // eslint-disable-next-line
     const overrideSettings: any = {

--- a/ldk/javascript/src/webpack/generate-ldk-settings.test.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.test.ts
@@ -1,0 +1,77 @@
+import { mergeLdkSettings } from './generate-ldk-settings';
+
+describe('Merge LDK Settings', () => {
+  // Have to force any type here to allow mergeLdkSettings to accept this shape
+  // eslint-disable-next-line
+  const baseLdkSettings: any = {
+    ldk: {
+      permissions: {
+        filesystem: {
+          pathGlobs: [{ value: '/base/path' }],
+        },
+        network: {
+          urlDomains: [{ value: 'baseUrl.com' }],
+        },
+        clipboard: {},
+        whisper: {},
+      },
+    },
+  };
+
+  it('replaces base urlDomains with override urlDomains', () => {
+    const overrideUrlDomains = [{ value: 'overrideUrl.com' }];
+    // Have to force any type here to allow mergeLdkSettings to accept this shape
+    // eslint-disable-next-line
+    const overrideSettings: any = {
+      ldk: {
+        permissions: {
+          network: {
+            urlDomains: overrideUrlDomains,
+          },
+        },
+      },
+    };
+
+    const mergedSettings = mergeLdkSettings(baseLdkSettings, overrideSettings);
+
+    const expectedSettings = baseLdkSettings;
+    expectedSettings.ldk.permissions.network.urlDomains = overrideUrlDomains;
+
+    expect(mergedSettings).toEqual(expectedSettings);
+  });
+
+  it('replaces base pathGlobs with override pathGlobs', () => {
+    const overridePathGlobs = [{ value: '/override/path' }];
+    // Have to force any type here to allow mergeLdkSettings to accept this shape
+    // eslint-disable-next-line
+    const overrideSettings: any = {
+      ldk: {
+        permissions: {
+          filesystem: {
+            pathGlobs: overridePathGlobs,
+          },
+        },
+      },
+    };
+
+    const mergedSettings = mergeLdkSettings(baseLdkSettings, overrideSettings);
+
+    const expectedSettings = baseLdkSettings;
+    expectedSettings.ldk.permissions.filesystem.pathGlobs = overridePathGlobs;
+
+    expect(mergedSettings).toEqual(expectedSettings);
+  });
+
+  it('keys present in the base config exist in merged output', () => {
+    // Have to force any type here to allow mergeLdkSettings to accept this shape
+    // eslint-disable-next-line
+    const overrideSettings: any = {
+      ldk: {
+        permissions: {},
+      },
+    };
+
+    const mergedSettings = mergeLdkSettings(baseLdkSettings, overrideSettings);
+    expect(mergedSettings).toEqual(baseLdkSettings);
+  });
+});

--- a/ldk/javascript/src/webpack/generate-ldk-settings.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import { customizeArray, CustomizeRule, mergeWithCustomize } from 'webpack-merge';
+import { LdkSettings } from './ldk-settings';
+
+export function mergeLdkSettings(
+  baseSettings: LdkSettings,
+  overrideSettings: LdkSettings,
+): LdkSettings {
+  return mergeWithCustomize<LdkSettings>({
+    customizeArray: customizeArray({
+      'ldk.permissions.network.urlDomains.*': CustomizeRule.Replace,
+      'ldk.permissions.filesystem.pathGlobs.*': CustomizeRule.Replace,
+    }),
+  })(baseSettings, overrideSettings);
+}
+
+export function generateLdkSettings(): LdkSettings {
+  // Need to dynamically refer to Loop's package.json
+  // Suppressing rule as we intentionally want a dynamic require.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
+  let ldkSettings: LdkSettings = require(path.join(process.cwd(), '/package.json'));
+
+  if (process.env.LDK_CONFIG !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
+    const ldkOverrides: LdkSettings = require(path.join(
+      process.cwd(),
+      `/ldk-config.${process.env.LDK_CONFIG}.json`,
+    ));
+
+    ldkSettings = mergeLdkSettings(ldkSettings, ldkOverrides);
+  }
+
+  return ldkSettings;
+}

--- a/ldk/javascript/src/webpack/generate-ldk-settings.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.ts
@@ -21,13 +21,17 @@ export function generateLdkSettings(): LdkSettings {
   let ldkSettings: LdkSettings = require(path.join(process.cwd(), '/package.json'));
 
   if (process.env.LDK_CONFIG !== undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
-    const ldkOverrides: LdkSettings = require(path.join(
-      process.cwd(),
-      `/ldk-config.${process.env.LDK_CONFIG}.json`,
-    ));
-
-    ldkSettings = mergeLdkSettings(ldkSettings, ldkOverrides);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
+      const ldkOverrides: LdkSettings = require(path.join(
+        process.cwd(),
+        `/ldk-config.${process.env.LDK_CONFIG}.json`,
+      ));
+      ldkSettings = mergeLdkSettings(ldkSettings, ldkOverrides);
+    } catch (err) {
+      console.error(`Failed to load environment config for LDK_CONFIG=${process.env.LDK_CONFIG}.`);
+      console.error(err.message);
+    }
   }
 
   return ldkSettings;


### PR DESCRIPTION
This commit adds configurable LDK permissions via an optional config
file and LDK_CONFIG env variable which can be set during the Webpack
build.

The commit adds new Webpack configuration in support of this change,
along with testing and documentation changes.