### PR TITLE
Exclude email self test

### DIFF
--- a/ldk/javascript/examples/self-test-loop/package.json
+++ b/ldk/javascript/examples/self-test-loop/package.json
@@ -33,7 +33,8 @@
       "filesystem": {},
       "process": {},
       "ui": {},
-      "user": {},
+      "user": {
+      },
       "system": {},
       "keyboard": {},
       "whisper": {},

--- a/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
@@ -6,8 +6,14 @@ import * as userTests from '../tests/user';
 export const userTestGroup = (): TestGroup =>
   new TestGroup('User Aptitude', [
     new LoopTest(
-      'User Aptitude - JWT - No Email Claim',
+      'User Aptitude - JWT - Default Claims',
       userTests.testJwt,
+      10000,
+      'No action required',
+    ),
+    new LoopTest(
+      'User Aptitude - JWT - No Email Claim',
+      userTests.testJwtExcludeEmail,
       10000,
       'No action required',
     ),

--- a/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
@@ -5,7 +5,39 @@ export const testJwt = (): Promise<boolean> =>
     user.jwt().then((token) => {
       if (token) {
         whisper.create({
-          label: 'User Aptitude JWT - No Email',
+          label: 'User Aptitude JWT - Default Claims',
+          components: [
+            {
+              type: whisper.WhisperComponentType.Markdown,
+              body: 'You can paste the token into jwt.io to check the claims.',
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to copy the JWT to your clipboard.',
+              onClick: async () => {
+                await clipboard.write(token);
+              },
+            },
+            {
+              type: whisper.WhisperComponentType.Link,
+              text: 'Click here to open jwt.io',
+              href: 'https://jwt.io',
+            },
+          ],
+        });
+        resolve(true);
+      } else {
+        reject(new Error('JWT should not have been empty'));
+      }
+    });
+  });
+
+export const testJwtExcludeEmail = (): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    user.jwt({ includeEmail: false }).then((token) => {
+      if (token) {
+        whisper.create({
+          label: 'User Aptitude JWT - Exclude Email Claim',
           components: [
             {
               type: whisper.WhisperComponentType.Markdown,
@@ -38,7 +70,7 @@ export const testJwtIncludeEmail = (): Promise<boolean> =>
     user.jwt({ includeEmail: true }).then((token) => {
       if (token) {
         whisper.create({
-          label: 'User Aptitude JWT - Include Email',
+          label: 'User Aptitude JWT - Include Email Claim',
           components: [
             {
               type: whisper.WhisperComponentType.Markdown,


### PR DESCRIPTION
This commit adds a test to the self test loop for exercising the JWT call when called with `{includeEmail: false}`.