### PR TITLE
HELPS-778 Update error message char limit to 50

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -2054,7 +2054,7 @@ export const testRichTextEditor = (): Promise<boolean> =>
               onClick: (_error: Error, onClickWhisper: Whisper) => {
                 if (!editedText || editedText.length === 0 || editedText.length > 50) {
                   (components[0] as RichTextEditor).validationError =
-                    'Inputed text is required and should be less than 200 chars.';
+                    'Inputed text is required and should be less than 50 chars.';
                   onClickWhisper.update({
                     components,
                   });


### PR DESCRIPTION
Update error message character limit accordingly in RichText Editor test loop.