### PR TITLE
[HELPS-1558] Bump version to 3.4.0

### DIFF
--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/ldk",
-  "version": "3.2.0",
+  "version": "3.4.0-beta.1",
   "description": "The Loop Development Kit for Olive Helps.",
   "author": "Olive",
   "copyright": "Copyright 2021 Olive",


### PR DESCRIPTION
This PR bumps the version number to 3.4.0.

Currently left in draft for beta releases.