### PR TITLE
[HELPS-1579] Add test for setting text input to empty string

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
@@ -132,6 +132,7 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
   new Promise(async (resolve, reject) => {
     try {
       const text1 = createTextComponent('text1');
+      const textToEmpty = createTextComponent('textToEmpty', 'type something in');
       const select1 = createSelectComponent('select1', 'Select Option 1');
       const autocomplete1 = createAutocompleteComponent(
         'autocomplete1',
@@ -141,6 +142,7 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
         label: 'Values should be overwritten after update',
         components: [
           text1,
+          textToEmpty,
           select1,
           autocomplete1,
           createButtonComponent('Update', (error: Error, onClickWhisper: Whisper) => {
@@ -150,12 +152,15 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
             }
             // Updating whisper with new component values
             text1.value = 'overwritten';
+            textToEmpty.value = '';
+            textToEmpty.label = "should now be empty";
             select1.selected = 1;
             autocomplete1.value = '2';
             onClickWhisper.update({
               components: [
                 createTextComponent('textNew', 'New Text Field'),
                 text1,
+                textToEmpty,
                 createSelectComponent('selectNew', 'New Select Field'),
                 select1,
                 autocomplete1,

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
@@ -153,7 +153,7 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
             // Updating whisper with new component values
             text1.value = 'overwritten';
             textToEmpty.value = '';
-            textToEmpty.label = "should now be empty";
+            textToEmpty.label = 'should now be empty';
             select1.selected = 1;
             autocomplete1.value = '2';
             onClickWhisper.update({

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/whisper-update.ts
@@ -134,8 +134,13 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
       const text1 = createTextComponent('text1');
       const textToEmpty = createTextComponent('textToEmpty', 'type something in');
       const select1 = createSelectComponent('select1', 'Select Option 1');
+      const selectToEmpty = createSelectComponent('select2', 'Select Option 1');
       const autocomplete1 = createAutocompleteComponent(
         'autocomplete1',
+        'Select an Autocomplete Option 1',
+      );
+      const acToEmpty = createAutocompleteComponent(
+        'autocomplete2',
         'Select an Autocomplete Option 1',
       );
       whisper.create({
@@ -144,7 +149,9 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
           text1,
           textToEmpty,
           select1,
+          selectToEmpty,
           autocomplete1,
+          acToEmpty,
           createButtonComponent('Update', (error: Error, onClickWhisper: Whisper) => {
             if (error) {
               console.error(error);
@@ -155,7 +162,11 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
             textToEmpty.value = '';
             textToEmpty.label = 'should now be empty';
             select1.selected = 1;
+            selectToEmpty.selected = -1;
+            selectToEmpty.label = 'should now be unselected';
             autocomplete1.value = '2';
+            acToEmpty.value = '';
+            acToEmpty.label = 'should now be empty';
             onClickWhisper.update({
               components: [
                 createTextComponent('textNew', 'New Text Field'),
@@ -163,7 +174,9 @@ export const testValueOverwrittenOnUpdate = (): Promise<boolean> =>
                 textToEmpty,
                 createSelectComponent('selectNew', 'New Select Field'),
                 select1,
+                selectToEmpty,
                 autocomplete1,
+                acToEmpty,
                 resolveRejectButtons(resolve, reject, 'Values overwritten', 'Values persisted'),
               ],
             });

--- a/ldk/javascript/src/webpack/generate-banner.test.ts
+++ b/ldk/javascript/src/webpack/generate-banner.test.ts
@@ -42,7 +42,7 @@ describe('Generate Banner', () => {
   it('generates banner given valid LdkSettings', () => {
     const actual = getLoopMetadataContent(generateBanner(ldkSettings));
     const expected = {
-      oliveHelpsContractVersion: '0.1.4',
+      oliveHelpsContractVersion: '0.1.5',
       permissions: {
         clipboard: {},
         cursor: {},
@@ -79,7 +79,7 @@ describe('Generate Banner', () => {
     const actual = getLoopMetadataContent(generateBanner(ldkSettings));
 
     const expected = {
-      oliveHelpsContractVersion: '0.1.4',
+      oliveHelpsContractVersion: '0.1.5',
       permissions: {
         filesystem: { pathGlobs: [{ value: '/my/path' }] },
         network: { urlDomains: [{ value: '*.google.com' }] },

--- a/ldk/javascript/src/webpack/generate-banner.test.ts
+++ b/ldk/javascript/src/webpack/generate-banner.test.ts
@@ -93,7 +93,7 @@ describe('Generate Banner', () => {
   it('adds oliveHelpsContractVersion', () => {
     const result = getLoopMetadataContent(generateBanner(ldkSettings));
 
-    expect(result.oliveHelpsContractVersion).toEqual('0.1.4');
+    expect(result.oliveHelpsContractVersion).toEqual('0.1.5');
   });
 
   it('throws exception when LDK permissions are not provided', () => {


### PR DESCRIPTION
This PR adds a test for setting the text input to an emptry string and confirming that the input's contents are cleared.

Tests fix for #359.