### PR TITLE
Revert Chrome Extension to Manifest V2

### DIFF
--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -1,14 +1,21 @@
+let timeout = 2;
 let connect = () => {
   console.log('connecting');
 
   const ws = new WebSocket('ws://127.0.0.1:24984');
 
   ws.addEventListener('close', (event) => {
-    setTimeout(connect, 1000);
+    if (timeout < 1000) {
+      timeout *= 2;
+    } else {
+      timeout = 1000;
+    }
+    setTimeout(connect, timeout);
   });
 
   ws.addEventListener('open', (event) => {
     console.log('connected');
+    timeout = 2;
 
     ws.addEventListener('message', function (event) {
       let callMessage = {};

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -2,7 +2,7 @@
   "name": "OliveHelps Browser Aptitude",
   "description": "OliveHelps Browser Aptitude Extension",
   "version": "0.1",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -11,8 +11,7 @@
     }
   ],
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
-  "permissions": ["tabs", "webRequest", "webNavigation"],
-  "host_permissions": ["http://localhost/*"]
+  "permissions": ["tabs", "webRequest", "webNavigation", "http://localhost/*"]
 }

--- a/extension/firefox/background.js
+++ b/extension/firefox/background.js
@@ -1,14 +1,21 @@
+let timeout = 2;
 let connect = () => {
   console.log('connecting');
 
   const ws = new WebSocket('ws://127.0.0.1:24984');
 
   ws.addEventListener('close', (event) => {
-    setTimeout(connect, 1000);
+    if (timeout < 1000) {
+      timeout *= 2;
+    } else {
+      timeout = 1000;
+    }
+    setTimeout(connect, timeout);
   });
 
   ws.addEventListener('open', (event) => {
     console.log('connected');
+    timeout = 2;
 
     ws.addEventListener('message', function (event) {
       let callMessage = {};


### PR DESCRIPTION
Service workers do not stay alive with their socket connections.

Long term, we will have to come up with a work-around.