### PR TITLE
HELPS-2001: Add Browser permission to LDK webpack config

### DIFF
--- a/ldk/javascript/src/webpack/generate-banner.test.ts
+++ b/ldk/javascript/src/webpack/generate-banner.test.ts
@@ -21,7 +21,7 @@ describe('Generate Banner', () => {
   const ldkSettings: LdkSettings = {
     ldk: {
       permissions: {
-        browser: {},
+        browser: { urlDomains: [{ value: '*.google.com' }] },
         clipboard: {},
         cursor: {},
         document: {},
@@ -45,7 +45,7 @@ describe('Generate Banner', () => {
     const expected = {
       oliveHelpsContractVersion: '0.1.7',
       permissions: {
-        browser: {},
+        browser: { urlDomains: [{ value: '*.google.com' }] },
         clipboard: {},
         cursor: {},
         document: {},

--- a/ldk/javascript/src/webpack/ldk-settings.ts
+++ b/ldk/javascript/src/webpack/ldk-settings.ts
@@ -17,7 +17,7 @@ export interface LdkUser {
   optionalClaims?: LdkValue[];
 }
 export interface LdkPermissions {
-  browser: LdkAptitude;
+  browser: LdkNetwork;
 
   clipboard: LdkAptitude;
 


### PR DESCRIPTION
[HELPS-2001](https://crosschx.atlassian.net/browse/HELPS-2001)

* Changed the `browser` permission type from `LdkAptitude` to `LdkNetwork` in order for users to add allowed URLs that the aptitude can open/watch.