### PR TITLE
Fix: npm publish workflow not installing packages before testing

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm run test
       - run: npm set audit false
       - run: npm ci
+      - run: npm run test
       - run: npm run build --if-present
       - run: printf '\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
       - run: npm publish --access public


### PR DESCRIPTION
* Moved the `npm run test` command to now run _after_ the `npm ci` (install) command