### PR TITLE
[Fix] Browser aptitude doc comment correction

### DIFF
--- a/ldk/javascript/src/browser/index.ts
+++ b/ldk/javascript/src/browser/index.ts
@@ -39,7 +39,7 @@ export interface Browser {
    * Opens a window in the browser running the Olive Helps extension.
    *
    * @param address - The address to navigate to in the new window.
-   * @returns The tab ID of the new tab inside the new window
+   * @returns The window ID of the new window
    */
   openWindow(address: string): Promise<number>;
 }


### PR DESCRIPTION
* Correcting the doc comment on the Browser aptitude's `openWindow` function, which incorrectly stated that it would return a tab ID.