### PR TITLE
HELPS-2100: Developers have no way to clear DateTime inputs once a value is set

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -1874,6 +1874,7 @@ export const testDateTime = (): Promise<boolean> =>
       ['Date', false],
       ['Time', false],
       ['DateTime', false],
+      ['ClearedDateTime', false],
     ]);
 
     try {
@@ -1925,6 +1926,30 @@ export const testDateTime = (): Promise<boolean> =>
           tooltip: 'Date/Time picker',
           min: new Date(2020, 0, 1),
           value: new Date(2021, 4, 5),
+          max: new Date(2022, 11, 31),
+        },
+        {
+          type: WhisperComponentType.DateTimeInput,
+          key: 'clearedDateTimeId',
+          id: 'clearedDateTimeId',
+          label: 'Cleared Date and Time',
+          dateTimeType: DateTimeType.DateTime,
+          onChange: (error: Error, param: string, onChangeWhisper: Whisper) => {
+            if (param) {
+              console.debug(`ClearedDateTime picker value received: ${param}`);
+              onActionWrapper(
+                error,
+                'ClearedDateTime',
+                resolverMap,
+                onChangeWhisper,
+                resolve,
+                reject,
+              );
+            }
+          },
+          tooltip: 'Date/Time picker',
+          min: new Date(2020, 0, 1),
+          value: '',
           max: new Date(2022, 11, 31),
         },
       ];

--- a/ldk/javascript/src/whisper/mapper.ts
+++ b/ldk/javascript/src/whisper/mapper.ts
@@ -275,11 +275,13 @@ export function mapToInternalChildComponent(
       } as WhisperService.TextInput;
     case WhisperComponentType.DateTimeInput:
       if (component.id && component.value) {
-        stateMap.set(component.id, component.value.toISOString());
+        const value =
+          component.value instanceof Date ? component.value.toISOString() : component.value;
+        stateMap.set(component.id, value);
       }
       return {
         ...component,
-        value: component.value?.toISOString(),
+        value: component.value instanceof Date ? component.value?.toISOString() : component.value,
         max: component.max?.toISOString(),
         min: component.min?.toISOString(),
         onChange: (error, param, whisper) => {

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -348,7 +348,11 @@ export type Telephone = InputComponent<WhisperComponentType.Telephone, string>;
 
 export type TextInput = InputComponent<WhisperComponentType.TextInput, string>;
 
-export type DateTimeInput = InputComponent<WhisperComponentType.DateTimeInput, Date, string> & {
+export type DateTimeInput = InputComponent<
+  WhisperComponentType.DateTimeInput,
+  Date | string,
+  string
+> & {
   dateTimeType: DateTimeType;
   min?: Date;
   max?: Date;


### PR DESCRIPTION
[HELPS-2100](https://crosschx.atlassian.net/browse/HELPS-2100)

* Updated `DateTimeInput` component to allow strings for the `value` prop, in order to send an empty string to clear it
* Updated DateTime self test loop with a DateTime component containing an empty string value