### PR TITLE
Helps 2614 ocr experimental screen detection methods

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/screen-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/screen-group.ts
@@ -6,9 +6,33 @@ import * as screenTests from '../tests/screen';
 export const screenTestGroup = (): TestGroup =>
   new TestGroup('Screen Aptitude', [
     new LoopTest(
-      'Screem Aptitude - OCR',
+      'Screen Aptitude - OCR',
       screenTests.testOCR,
       10000,
       'Can you see recognized text?.',
+    ),
+    new LoopTest(
+      'Screen Aptitude - Compare Hash',
+      screenTests.testCompareHash,
+      10000,
+      'Checking hashes...',
+    ),
+    new LoopTest(
+      'Screen Aptitude - Fullscreen Hash',
+      screenTests.testFullScreenHash,
+      10000,
+      'Generating hashes from fullscreen...',
+    ),
+    new LoopTest(
+      'Screen Aptitude - Screen Hash',
+      screenTests.testScreenHash,
+      10000,
+      'Generating hashes...',
+    ),
+    new LoopTest(
+      'Screen Aptitude - Listen Functions',
+      screenTests.testListenFunctions,
+      10000,
+      'Please open a new fullscreen window and change the contents (A browser works well for this).',
     ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/hashTests.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/hashTests.ts
@@ -1,0 +1,171 @@
+import { screen } from '@oliveai/ldk';
+import { Bounds, HashType } from '@oliveai/ldk/dist/screen';
+import { Cancellable } from '../../../../../dist/cancellable';
+
+export const testFullScreenHash = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const fullScreen: Bounds = {
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+      };
+
+      const sensitivity: number = 1;
+
+      await screen.hash(fullScreen, sensitivity);
+      const averageHash = await screen.hash(fullScreen, sensitivity, HashType.Average);
+      const differenceHash = await screen.hash(fullScreen, sensitivity, HashType.Difference);
+      const perceptionHash = await screen.hash(fullScreen, sensitivity, HashType.Perception);
+
+      const usedDifferentAlg =
+        averageHash != differenceHash &&
+        averageHash != perceptionHash &&
+        differenceHash != perceptionHash;
+      if (usedDifferentAlg) {
+        resolve(true);
+      } else {
+        reject('Algorithm hashes returned the same');
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+export const testScreenHash = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const fullScreen: Bounds = {
+        top: 0,
+        left: 0,
+        width: 512,
+        height: 512,
+      };
+
+      const sensitivity: number = 1;
+
+      await screen.hash(fullScreen, sensitivity);
+      const averageHash = await screen.hash(fullScreen, sensitivity, HashType.Average);
+      const differenceHash = await screen.hash(fullScreen, sensitivity, HashType.Difference);
+      const perceptionHash = await screen.hash(fullScreen, sensitivity, HashType.Perception);
+
+      const usedDifferentAlg =
+        averageHash != differenceHash &&
+        averageHash != perceptionHash &&
+        differenceHash != perceptionHash;
+      if (usedDifferentAlg) {
+        resolve(true);
+      } else {
+        reject('Algorithm hashes returned the same');
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+export const testCompareHash = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const hashA = 'bbbb';
+      const hashB = 'cccc';
+      const expectedDistance = 4;
+
+      let distance = await screen.compareHash(hashA, hashB);
+      if (distance != expectedDistance) {
+        reject(`Distance between ${hashA} and ${hashB} resulted in ${distance}`);
+      }
+
+      distance = await screen.compareHash(hashA, hashA);
+      if (distance != 0) {
+        reject('Same hash resulted in a distance != 0');
+      }
+
+      resolve(true);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+export const testListenFunctions = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      const verified: { [key: string]: boolean } = {
+        average: false,
+        perception: false,
+        difference: false,
+        pixelDiff: false,
+        activeWindow: false,
+      };
+
+      const listeners: { [key: string]: Cancellable } = {};
+
+      const delayMs = 2500;
+      const sensitivity = 1;
+      HashType.Average;
+      const threshold = 3;
+      const bounds = {
+        top: 0,
+        left: 0,
+        width: 256,
+        height: 256,
+      };
+
+      function verifyAllCalled() {
+        if (Object.values(verified).indexOf(false) == -1) {
+          resolve(true);
+        }
+      }
+
+      function generateCb(fnType: string) {
+        return (distance: number) => {
+          verified[fnType] = true;
+          listeners[fnType].cancel();
+          setTimeout(verifyAllCalled, 0);
+        };
+      }
+
+      screen
+        .listenHash(
+          bounds,
+          threshold,
+          delayMs,
+          sensitivity,
+          HashType.Average,
+          generateCb('average'),
+        )
+        .then((cancellable) => (listeners['average'] = cancellable));
+
+      screen
+        .listenHash(
+          bounds,
+          threshold,
+          delayMs,
+          sensitivity,
+          HashType.Perception,
+          generateCb('perception'),
+        )
+        .then((cancellable) => (listeners['perception'] = cancellable));
+
+      screen
+        .listenHash(
+          bounds,
+          threshold,
+          delayMs,
+          sensitivity,
+          HashType.Difference,
+          generateCb('difference'),
+        )
+        .then((cancellable) => (listeners['difference'] = cancellable));
+
+      screen
+        .listenPixelDiff(bounds, threshold, delayMs, generateCb('pixelDiff'))
+        .then((cancellable) => (listeners['pixelDiff'] = cancellable));
+
+      screen
+        .listenPixelDiffActiveWindow(threshold, delayMs, generateCb('activeWindow'))
+        .then((cancellable) => (listeners['activeWindow'] = cancellable));
+    } catch (error) {
+      reject(error);
+    }
+  });

--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-async-promise-executor */
 import { screen, whisper, window } from '@oliveai/ldk';
 
+export * from './hashTests';
+
 const writeWhisper = (label: string, body: string) =>
   whisper.create({
     label,
@@ -108,4 +110,4 @@ export async function performOcr() {
   });
 }
 
-console.log(`Starting app`);
+

--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
@@ -109,5 +109,3 @@ export async function performOcr() {
       });
   });
 }
-
-

--- a/ldk/javascript/src/promisify.ts
+++ b/ldk/javascript/src/promisify.ts
@@ -206,6 +206,60 @@ export function promisifyListenableWithParam<TParam, TOut>(
   });
 }
 
+export function promisifyListenableWithTwoParams<TParam1, TParam2, TOut>(
+  param: TParam1,
+  param2: TParam2,
+  cb: (v: TOut) => void,
+  arg: Common.ListenableWithTwoParams<TParam1, TParam2, TOut>,
+): Promise<Cancellable> {
+  return new Promise((resolve, reject) => {
+    try {
+      arg(param, param2, handleListenerCallback(cb), (obj) => {
+        resolve(obj);
+      });
+    } catch (e) {
+      handleCaughtError(reject, e as Error);
+    }
+  });
+}
+
+export function promisifyListenableWithThreeParams<TParam1, TParam2, TParam3, TOut>(
+  param: TParam1,
+  param2: TParam2,
+  param3: TParam3,
+  cb: (v: TOut) => void,
+  arg: Common.ListenableWithThreeParams<TParam1, TParam2, TParam3, TOut>,
+): Promise<Cancellable> {
+  return new Promise((resolve, reject) => {
+    try {
+      arg(param, param2, param3, handleListenerCallback(cb), (obj) => {
+        resolve(obj);
+      });
+    } catch (e) {
+      handleCaughtError(reject, e as Error);
+    }
+  });
+}
+
+export function promisifyListenableWithFourParams<TParam1, TParam2, TParam3, TParam4, TOut>(
+  param: TParam1,
+  param2: TParam2,
+  param3: TParam3,
+  param4: TParam4,
+  cb: (v: TOut) => void,
+  arg: Common.ListenableWithFourParams<TParam1, TParam2, TParam3, TParam4, TOut>,
+): Promise<Cancellable> {
+  return new Promise((resolve, reject) => {
+    try {
+      arg(param, param2, param3, param4, handleListenerCallback(cb), (obj) => {
+        resolve(obj);
+      });
+    } catch (e) {
+      handleCaughtError(reject, e as Error);
+    }
+  });
+}
+
 export function promisifyMappedListenableWithParam<TParam, TInternalOut, TExternalOut>(
   param: TParam,
   map: Mapper<TInternalOut, TExternalOut>,

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -123,13 +123,13 @@ export function listenHash(
     case HashType.Difference:
       listenFunc = oliveHelps.screen.listenDifferenceHash;
       break;
-      case HashType.Perception:
-        listenFunc = oliveHelps.screen.listenPerceptionHash;
-        break;
-      case HashType.Average:
-      default:
-        listenFunc = oliveHelps.screen.listenAverageHash;
-        break;
+    case HashType.Perception:
+      listenFunc = oliveHelps.screen.listenPerceptionHash;
+      break;
+    case HashType.Average:
+    default:
+      listenFunc = oliveHelps.screen.listenAverageHash;
+      break;
   }
 
   return promisifyListenableWithFourParams(

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -93,13 +93,14 @@ export function ocr(ocrCoordinates: OCRCoordinates): Promise<OCRResult[]> {
 }
 
 export function hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): Promise<string> {
-  hashType = hashType || HashType.Average;
-  switch (hashType) {
+  const defaultOrHashType = hashType || HashType.Average;
+  switch (defaultOrHashType) {
     case HashType.Difference:
       return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.differenceHash);
     case HashType.Perception:
       return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.perceptionHash);
     case HashType.Average:
+    default:
       return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.averageHash);
   }
 }
@@ -119,15 +120,16 @@ export function listenHash(
   let listenFunc: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
 
   switch (hashType) {
-    case HashType.Average:
-      listenFunc = oliveHelps.screen.listenAverageHash;
-      break;
     case HashType.Difference:
       listenFunc = oliveHelps.screen.listenDifferenceHash;
       break;
-    case HashType.Perception:
-      listenFunc = oliveHelps.screen.listenPerceptionHash;
-      break;
+      case HashType.Perception:
+        listenFunc = oliveHelps.screen.listenPerceptionHash;
+        break;
+      case HashType.Average:
+      default:
+        listenFunc = oliveHelps.screen.listenAverageHash;
+        break;
   }
 
   return promisifyListenableWithFourParams(

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -1,5 +1,12 @@
-import { promisifyWithParam } from '../promisify';
-import { OCRResult, OCRCoordinates } from './types';
+import { Cancellable } from '../cancellable';
+import {
+  promisifyListenableWithFourParams,
+  promisifyListenableWithThreeParams,
+  promisifyListenableWithTwoParams,
+  promisifyWithParam,
+  promisifyWithTwoParams,
+} from '../promisify';
+import { Bounds, HashType, OCRResult, OCRCoordinates } from './types';
 
 export * from './types';
 
@@ -13,8 +20,150 @@ export interface Screen {
    * @returns A Promise resolving with the text results as a string.
    */
   ocr(ocrCoordinates?: OCRCoordinates): Promise<OCRResult[]>;
+
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * Calculates the image hash of the specified screen area using the specified hash algorithm
+   * @param bounds - The area on the screen where to take the hash.
+   * @param sensitivity - Controls the hash size. Larger hash sizes will be more sensitive to changes. Exceeding a value of 3 will result in a very slow calculation and is not recommended. Must be a positive integer.
+   * @param hashType? - Specifies the type of hash to use. By default it uses the average hashing algorithm.
+   * @returns A promise resolving with the hash of the selected area
+   */
+  hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): Promise<string>;
+
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * Returns the hamming distance between the two hashes. The more the hashes differ, the larger the distance will be. If the hashes are equal, the distance will be 0.
+   * @param hashA - The first hash to compare
+   * @param hashB - The second hash to compare
+   * @returns A promise with the hamming distance from hashA to hashB
+   */
+  compareHash(hashA: string, hashB: string): Promise<bigint>;
+
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * Monitors the specified screen area for changes. The callback is called when a change is detected. The screen is considered different when the distance between subsequent hashes exceeds the provided threshold.
+   * @param bounds - The area on the screen to monitor for changes
+   * @param threshold - The distance between subsequent hashes required to trigger the callback. Must be a positive integer.
+   * @param delayMs - The delay in milliseconds between checks. Must be a positive integer.
+   * @param sensitivity -controls the hash size. Larger hash sizes will be more sensitive to changes. Exceeding a value of 3 will result in a very slow calculation and is not recommended. Must be a positive integer.
+   * @param hashType - Specifies the type of hash to use
+   * @param callback - The function called when the distance between hashes results in a value higher than the specified threshold value.
+   */
+  listenHash(
+    bounds: Bounds,
+    threshold: bigint,
+    delayMs: bigint,
+    sensitivity: bigint,
+    hashType: HashType,
+    callback: (distance: bigint) => void,
+  ): Promise<Cancellable>;
+
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * Monitors the specified screen area for changes. The callback is called when a change is detected. The screen is considered different when the distance between subsequent hashes exceeds the provided threshold. This counts the number of differences in the image by pixel component. The returned difference is a number between 0 and 1. A difference of 0 means the images are the same. A difference of 1 means the images are entirely different.
+   * @param bounds - The area on the screen to monitor for changes
+   * @param threshold - The required difference to trigger the callback. Ranges from 0-1.
+   * @param delayMs - The delay in milliseconds between checks. Must be a positive integer.
+   * @param callback - The function to call when a change is detected
+   */
+  listenPixelDiff(
+    bounds: Bounds,
+    threshold: number,
+    delayMs: bigint,
+    callback: (difference: number) => void,
+  ): Promise<Cancellable>;
+
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * Monitors the active window for changes. The callback is called when a change is detected. The screen is considered different when the distance between subsequent hashes exceeds the provided threshold. This counts the number of differences in the image by pixel component. The returned difference is a number between 0 and 1. A difference of 0 means the images are the same. A difference of 1 means the images are entirely different.
+   * @param threshold - The required difference to trigger the callback. Rnages from 0-1.
+   * @param delayMs - The delay in milliseconds between checks. Must be a positive integer.
+   * @param callback - The function to call when a change is detected
+   */
+  listenPixelDiffActiveWindow(
+    threshold: number,
+    delayMs: bigint,
+    callback: (difference: number) => void,
+  ): Promise<Cancellable>;
 }
 
 export function ocr(ocrCoordinates: OCRCoordinates): Promise<OCRResult[]> {
   return promisifyWithParam(ocrCoordinates, oliveHelps.screen.ocr);
+}
+
+export function hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): Promise<string> {
+  hashType = hashType || HashType.Average;
+  switch (hashType) {
+    case HashType.Difference:
+      return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.differenceHash);
+    case HashType.Perception:
+      return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.perceptionHash);
+    case HashType.Average:
+      return promisifyWithTwoParams(bounds, sensitivity, oliveHelps.screen.averageHash);
+  }
+}
+
+export function compareHash(hashA: string, hashB: string): Promise<bigint> {
+  return promisifyWithTwoParams(hashA, hashB, oliveHelps.screen.compareHashes);
+}
+
+export function listenHash(
+  bounds: Bounds,
+  threshold: bigint,
+  delayMs: bigint,
+  sensitivity: bigint,
+  hashType: HashType,
+  callback: (distance: bigint) => void,
+): Promise<Cancellable> {
+  let listenFunc: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
+
+  switch (hashType) {
+    case HashType.Average:
+      listenFunc = oliveHelps.screen.listenAverageHash;
+      break;
+    case HashType.Difference:
+      listenFunc = oliveHelps.screen.listenDifferenceHash;
+      break;
+    case HashType.Perception:
+      listenFunc = oliveHelps.screen.listenPerceptionHash;
+      break;
+  }
+
+  return promisifyListenableWithFourParams(
+    bounds,
+    threshold,
+    delayMs,
+    sensitivity,
+    callback,
+    listenFunc,
+  );
+}
+
+export function listenPixelDiff(
+  bounds: Bounds,
+  threshold: number,
+  delayMs: bigint,
+  callback: (difference: number) => void,
+): Promise<Cancellable> {
+  return promisifyListenableWithThreeParams(
+    bounds,
+    threshold,
+    delayMs,
+    callback,
+    oliveHelps.screen.listenPixelDiff,
+  );
+}
+
+export function listenPixelDiffActiveWindow(
+  threshold: number,
+  delayMs: bigint,
+  callback: (difference: number) => void,
+): Promise<Cancellable> {
+  return promisifyListenableWithTwoParams(
+    threshold,
+    delayMs,
+    callback,
+    oliveHelps.screen.listenPixelDiffActiveWindow,
+  );
 }

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -29,7 +29,7 @@ export interface Screen {
    * @param hashType? - Specifies the type of hash to use. By default it uses the average hashing algorithm.
    * @returns A promise resolving with the hash of the selected area
    */
-  hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): Promise<string>;
+  hash(bounds: Bounds, sensitivity: number, hashType?: HashType): Promise<string>;
 
   /**
    * @experimental This functionality is experimental and subject to breaking changes.
@@ -38,7 +38,7 @@ export interface Screen {
    * @param hashB - The second hash to compare
    * @returns A promise with the hamming distance from hashA to hashB
    */
-  compareHash(hashA: string, hashB: string): Promise<bigint>;
+  compareHash(hashA: string, hashB: string): Promise<number>;
 
   /**
    * @experimental This functionality is experimental and subject to breaking changes.
@@ -52,11 +52,11 @@ export interface Screen {
    */
   listenHash(
     bounds: Bounds,
-    threshold: bigint,
-    delayMs: bigint,
-    sensitivity: bigint,
+    threshold: number,
+    delayMs: number,
+    sensitivity: number,
     hashType: HashType,
-    callback: (distance: bigint) => void,
+    callback: (distance: number) => void,
   ): Promise<Cancellable>;
 
   /**
@@ -70,7 +70,7 @@ export interface Screen {
   listenPixelDiff(
     bounds: Bounds,
     threshold: number,
-    delayMs: bigint,
+    delayMs: number,
     callback: (difference: number) => void,
   ): Promise<Cancellable>;
 
@@ -83,7 +83,7 @@ export interface Screen {
    */
   listenPixelDiffActiveWindow(
     threshold: number,
-    delayMs: bigint,
+    delayMs: number,
     callback: (difference: number) => void,
   ): Promise<Cancellable>;
 }
@@ -92,7 +92,7 @@ export function ocr(ocrCoordinates: OCRCoordinates): Promise<OCRResult[]> {
   return promisifyWithParam(ocrCoordinates, oliveHelps.screen.ocr);
 }
 
-export function hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): Promise<string> {
+export function hash(bounds: Bounds, sensitivity: number, hashType?: HashType): Promise<string> {
   const defaultOrHashType = hashType || HashType.Average;
   switch (defaultOrHashType) {
     case HashType.Difference:
@@ -105,19 +105,19 @@ export function hash(bounds: Bounds, sensitivity: bigint, hashType?: HashType): 
   }
 }
 
-export function compareHash(hashA: string, hashB: string): Promise<bigint> {
+export function compareHash(hashA: string, hashB: string): Promise<number> {
   return promisifyWithTwoParams(hashA, hashB, oliveHelps.screen.compareHashes);
 }
 
 export function listenHash(
   bounds: Bounds,
-  threshold: bigint,
-  delayMs: bigint,
-  sensitivity: bigint,
+  threshold: number,
+  delayMs: number,
+  sensitivity: number,
   hashType: HashType,
-  callback: (distance: bigint) => void,
+  callback: (distance: number) => void,
 ): Promise<Cancellable> {
-  let listenFunc: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
+  let listenFunc: Common.ListenableWithFourParams<Bounds, number, number, number, number>;
 
   switch (hashType) {
     case HashType.Difference:
@@ -145,7 +145,7 @@ export function listenHash(
 export function listenPixelDiff(
   bounds: Bounds,
   threshold: number,
-  delayMs: bigint,
+  delayMs: number,
   callback: (difference: number) => void,
 ): Promise<Cancellable> {
   return promisifyListenableWithThreeParams(
@@ -159,7 +159,7 @@ export function listenPixelDiff(
 
 export function listenPixelDiffActiveWindow(
   threshold: number,
-  delayMs: bigint,
+  delayMs: number,
   callback: (difference: number) => void,
 ): Promise<Cancellable> {
   return promisifyListenableWithTwoParams(

--- a/ldk/javascript/src/screen/screen.test.ts
+++ b/ldk/javascript/src/screen/screen.test.ts
@@ -6,6 +6,15 @@ describe('screen', () => {
   beforeEach(() => {
     oliveHelps.screen = {
       ocr: jest.fn(),
+      averageHash: jest.fn(),
+      differenceHash: jest.fn(),
+      perceptionHash: jest.fn(),
+      compareHashes: jest.fn(),
+      listenAverageHash: jest.fn(),
+      listenDifferenceHash: jest.fn(),
+      listenPerceptionHash: jest.fn(),
+      listenPixelDiff: jest.fn(),
+      listenPixelDiffActiveWindow: jest.fn(),
     };
   });
   describe('ocr', () => {

--- a/ldk/javascript/src/screen/types.ts
+++ b/ldk/javascript/src/screen/types.ts
@@ -20,3 +20,16 @@ export interface OCRCoordinates {
   width: number;
   height: number;
 }
+
+export type Bounds = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+export enum HashType {
+  Average,
+  Difference,
+  Perception,
+}

--- a/ldk/javascript/src/types/oliveHelps/common.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/common.d.ts
@@ -43,4 +43,28 @@ declare namespace Common {
     callback: Callback<TOut>,
     returnCb: ReturnCallback,
   ) => void;
+
+  type ListenableWithTwoParams<TParam1, TParam2, TOut> = (
+    param1: TParam1,
+    param2: TParam2,
+    callback: Callback<TOut>,
+    returnCb: ReturnCallback,
+  ) => void;
+
+  type ListenableWithThreeParams<TParam1, TParam2, TParam3, TOut> = (
+    param1: TParam1,
+    param2: TParam2,
+    param3: TParam3,
+    callback: Callback<TOut>,
+    returnCb: ReturnCallback,
+  ) => void;
+
+  type ListenableWithFourParams<TParam1, TParam2, TParam3, TParam4, TOut> = (
+    param1: TParam1,
+    param2: TParam2,
+    param3: TParam3,
+    param4: TParam4,
+    callback: Callback<TOut>,
+    returnCb: ReturnCallback,
+  ) => void;
 }

--- a/ldk/javascript/src/types/oliveHelps/screen.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/screen.d.ts
@@ -2,15 +2,15 @@
 declare namespace Screen {
   interface Aptitude {
     ocr: Common.ReadableWithParam<OCRCoordinates, OCRResult[]>;
-    averageHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
-    differenceHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
-    perceptionHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
-    compareHashes: Common.ReadableWithTwoParams<string, string, bigint>;
-    listenAverageHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
-    listenDifferenceHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
-    listenPerceptionHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
-    listenPixelDiff: Common.ListenableWithThreeParams<Bounds, number, bigint, number>;
-    listenPixelDiffActiveWindow: Common.ListenableWithTwoParams<number, bigint, number>;
+    averageHash: Common.ReadableWithTwoParams<Bounds, number, string>;
+    differenceHash: Common.ReadableWithTwoParams<Bounds, number, string>;
+    perceptionHash: Common.ReadableWithTwoParams<Bounds, number, string>;
+    compareHashes: Common.ReadableWithTwoParams<string, string, number>;
+    listenAverageHash: Common.ListenableWithFourParams<Bounds, number, number, number, number>;
+    listenDifferenceHash: Common.ListenableWithFourParams<Bounds, number, number, number, number>;
+    listenPerceptionHash: Common.ListenableWithFourParams<Bounds, number, number, number, number>;
+    listenPixelDiff: Common.ListenableWithThreeParams<Bounds, number, number, number>;
+    listenPixelDiffActiveWindow: Common.ListenableWithTwoParams<number, number, number>;
   }
 
   interface OCRResult {

--- a/ldk/javascript/src/types/oliveHelps/screen.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/screen.d.ts
@@ -2,6 +2,15 @@
 declare namespace Screen {
   interface Aptitude {
     ocr: Common.ReadableWithParam<OCRCoordinates, OCRResult[]>;
+    averageHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
+    differenceHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
+    perceptionHash: Common.ReadableWithTwoParams<Bounds, bigint, string>;
+    compareHashes: Common.ReadableWithTwoParams<string, string, bigint>;
+    listenAverageHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
+    listenDifferenceHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
+    listenPerceptionHash: Common.ListenableWithFourParams<Bounds, bigint, bigint, bigint, bigint>;
+    listenPixelDiff: Common.ListenableWithThreeParams<Bounds, number, bigint, number>;
+    listenPixelDiffActiveWindow: Common.ListenableWithTwoParams<number, bigint, number>;
   }
 
   interface OCRResult {
@@ -25,4 +34,11 @@ declare namespace Screen {
     width: number;
     height: number;
   }
+
+  type Bounds = {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  };
 }


### PR DESCRIPTION
Added support for listen*Hash, comparehash, and *hash (where * = average, difference, perception), as well as listenPixelDiff and listenPixelActiveWindow