### PR TITLE
HELPS-2776 onClose is not called for react whispers

### DIFF
--- a/ldk/javascript/package-lock.json
+++ b/ldk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oliveai/ldk",
-  "version": "3.7.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oliveai/ldk",
-      "version": "3.7.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.15.8",

--- a/ldk/javascript/src/whisper/react/readme.md
+++ b/ldk/javascript/src/whisper/react/readme.md
@@ -56,4 +56,3 @@ main();
 * We have targeted specific `react` and `react-reconciler` versions in the LDK. Weird things may happen if you use another version.
 * If you are using a local build of the LDK that's symlinked into your Loop's repo, you'll need to use a Webpack `resolve` alias to ensure that both the LDK and your Loop are using the same `react` library.
 * Text nodes are automatically converted into Markdown components. If you plan on using interpolation, we recommend that you use explicit Markdown components (`oh-markdown` element) and supply the Markdown text to be rendered in the `body` prop.
-* The way onClose currently works is a bit weird, it is required on oh-whisper, but it will only be hooked up to the close event if it's set as a prop on the top level component like in the example above

--- a/ldk/javascript/src/whisper/react/readme.md
+++ b/ldk/javascript/src/whisper/react/readme.md
@@ -38,7 +38,7 @@ function main() {
     if (textEntry) {
       return;
     }
-    ReactWhisper.renderNewWhisper(<Incrementer/>)
+    ReactWhisper.renderNewWhisper(<Incrementer onClose={() => console.log('closed')} />)
   };
   ldk.keyboard.listenHotkey({control: true, key: 'a'}, listener);
 }
@@ -56,3 +56,4 @@ main();
 * We have targeted specific `react` and `react-reconciler` versions in the LDK. Weird things may happen if you use another version.
 * If you are using a local build of the LDK that's symlinked into your Loop's repo, you'll need to use a Webpack `resolve` alias to ensure that both the LDK and your Loop are using the same `react` library.
 * Text nodes are automatically converted into Markdown components. If you plan on using interpolation, we recommend that you use explicit Markdown components (`oh-markdown` element) and supply the Markdown text to be rendered in the `body` prop.
+* The way onClose currently works is a bit weird, it is required on oh-whisper, but it will only be hooked up to the close event if it's set as a prop on the top level component like in the example above

--- a/ldk/javascript/src/whisper/react/renderer-config.ts
+++ b/ldk/javascript/src/whisper/react/renderer-config.ts
@@ -235,7 +235,7 @@ export const config: CoreConfig & PersistenceConfig = {
     };
     handler.assignTextChildren?.(instance, props);
     if (type === 'oh-whisper' && typeof props.onClose === 'function') {
-      rootContainer.setExternalOnClose(props.onClose)
+      rootContainer.setExternalOnClose(props.onClose);
     }
     if (internalHandle.key) {
       instance.key = internalHandle.key;

--- a/ldk/javascript/src/whisper/react/renderer-config.ts
+++ b/ldk/javascript/src/whisper/react/renderer-config.ts
@@ -234,6 +234,9 @@ export const config: CoreConfig & PersistenceConfig = {
       ...propsWithoutChildren,
     };
     handler.assignTextChildren?.(instance, props);
+    if (type === 'oh-whisper' && typeof props.onClose === 'function') {
+      rootContainer.setExternalOnClose(props.onClose)
+    }
     if (internalHandle.key) {
       instance.key = internalHandle.key;
     }

--- a/ldk/javascript/src/whisper/react/renderer.test.tsx
+++ b/ldk/javascript/src/whisper/react/renderer.test.tsx
@@ -323,6 +323,8 @@ describe('renderer', () => {
     });
   });
   describe('closing whispers', () => {
+    const callAllOnCloseHandlers = (mockedFn: jest.Mock) => Promise.all(mockedFn.mock.calls.map(call => call[0]()));
+
     it('returned object should call closeWhisper when programmatically closed', async () => {
       const onClose = jest.fn();
       const whisper = await render(
@@ -344,14 +346,26 @@ describe('renderer', () => {
         </oh-whisper>,
         whisperInterface,
       );
-      const closeHandler = mocked(whisperInterface.setOnClose).mock.calls[0][0];
-      await closeHandler();
+
+      await callAllOnCloseHandlers(mocked(whisperInterface.setOnClose));
       expect(whisperInterface.createOrUpdateWhisper).toHaveBeenCalledWith({
         components: [],
         label: '',
         onClose: expect.any(Function),
       });
       expect(onUnmount).toHaveBeenCalled();
+    });
+    it('when the whisper onClose prop is called it calls the users handler', async () => {
+      const onClose = jest.fn();
+      await render(
+        <oh-whisper label="whisper.label" onClose={onClose}>
+	        <oh-markdown body="markdown.body"/>
+        </oh-whisper>,
+        whisperInterface
+      );
+
+      await callAllOnCloseHandlers(mocked(whisperInterface.setOnClose))
+      expect(onClose).toHaveBeenCalled()
     });
   });
 });

--- a/ldk/javascript/src/whisper/react/renderer.test.tsx
+++ b/ldk/javascript/src/whisper/react/renderer.test.tsx
@@ -52,7 +52,7 @@ describe('renderer', () => {
       createOrUpdateWhisper: jest.fn(),
       closeWhisper: jest.fn(),
       setInternalOnClose: jest.fn(),
-      setExternalOnClose: jest.fn()
+      setExternalOnClose: jest.fn(),
     };
   });
 
@@ -358,13 +358,13 @@ describe('renderer', () => {
       const onClose = jest.fn();
       await render(
         <oh-whisper label="whisper.label" onClose={onClose}>
-	        <oh-markdown body="markdown.body"/>
+          <oh-markdown body="markdown.body" />
         </oh-whisper>,
-        whisperInterface
+        whisperInterface,
       );
 
       await mocked(whisperInterface.setExternalOnClose).mock.calls[0][0]();
-      expect(onClose).toHaveBeenCalled()
+      expect(onClose).toHaveBeenCalled();
     });
   });
 });

--- a/ldk/javascript/src/whisper/react/renderer.test.tsx
+++ b/ldk/javascript/src/whisper/react/renderer.test.tsx
@@ -51,7 +51,8 @@ describe('renderer', () => {
     whisperInterface = {
       createOrUpdateWhisper: jest.fn(),
       closeWhisper: jest.fn(),
-      setOnClose: jest.fn(),
+      setInternalOnClose: jest.fn(),
+      setExternalOnClose: jest.fn()
     };
   });
 
@@ -323,8 +324,6 @@ describe('renderer', () => {
     });
   });
   describe('closing whispers', () => {
-    const callAllOnCloseHandlers = (mockedFn: jest.Mock) => Promise.all(mockedFn.mock.calls.map(call => call[0]()));
-
     it('returned object should call closeWhisper when programmatically closed', async () => {
       const onClose = jest.fn();
       const whisper = await render(
@@ -347,7 +346,7 @@ describe('renderer', () => {
         whisperInterface,
       );
 
-      await callAllOnCloseHandlers(mocked(whisperInterface.setOnClose));
+      await mocked(whisperInterface.setInternalOnClose).mock.calls[0][0]();
       expect(whisperInterface.createOrUpdateWhisper).toHaveBeenCalledWith({
         components: [],
         label: '',
@@ -364,7 +363,7 @@ describe('renderer', () => {
         whisperInterface
       );
 
-      await callAllOnCloseHandlers(mocked(whisperInterface.setOnClose))
+      await mocked(whisperInterface.setExternalOnClose).mock.calls[0][0]();
       expect(onClose).toHaveBeenCalled()
     });
   });

--- a/ldk/javascript/src/whisper/react/renderer.ts
+++ b/ldk/javascript/src/whisper/react/renderer.ts
@@ -1,5 +1,5 @@
 import * as Reconciler from 'react-reconciler';
-import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { config } from './renderer-config';
 import { WhisperRenderingInterface, WhisperRenderInstance } from './whisper-render-instance';
 // This side effect import makes the JSX namespace addition available without
@@ -13,13 +13,9 @@ import { WhisperInstance, WhisperInstanceWrapper } from './whisper-instance-wrap
 const renderer = Reconciler.default(config);
 
 export async function render(
-  element: ReactElement,
+  element: ReactNode,
   whisperInterface: WhisperRenderingInterface,
 ): Promise<WhisperInstance> {
-  if (typeof element.props.onClose === 'function') {
-    whisperInterface.setOnClose(element.props.onClose)
-  }
-
   // Tag here drives what sort of "modes" its using. 0 = LegacyRoot.
   const container = renderer.createContainer(whisperInterface, 0, false, null);
   const wrapper = new WhisperInstanceWrapper(container, whisperInterface, renderer);
@@ -31,7 +27,7 @@ export async function render(
  *
  * @param element
  */
-export function renderNewWhisper(element: ReactElement): Promise<WhisperInstance> {
+export function renderNewWhisper(element: ReactNode): Promise<WhisperInstance> {
   return render(element, new WhisperRenderInstance());
 }
 

--- a/ldk/javascript/src/whisper/react/renderer.ts
+++ b/ldk/javascript/src/whisper/react/renderer.ts
@@ -1,5 +1,5 @@
 import * as Reconciler from 'react-reconciler';
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import { config } from './renderer-config';
 import { WhisperRenderingInterface, WhisperRenderInstance } from './whisper-render-instance';
 // This side effect import makes the JSX namespace addition available without
@@ -13,9 +13,13 @@ import { WhisperInstance, WhisperInstanceWrapper } from './whisper-instance-wrap
 const renderer = Reconciler.default(config);
 
 export async function render(
-  element: ReactNode,
+  element: ReactElement,
   whisperInterface: WhisperRenderingInterface,
 ): Promise<WhisperInstance> {
+  if (typeof element.props.onClose === 'function') {
+    whisperInterface.setOnClose(element.props.onClose)
+  }
+
   // Tag here drives what sort of "modes" its using. 0 = LegacyRoot.
   const container = renderer.createContainer(whisperInterface, 0, false, null);
   const wrapper = new WhisperInstanceWrapper(container, whisperInterface, renderer);
@@ -27,8 +31,7 @@ export async function render(
  *
  * @param element
  */
-export function renderNewWhisper(element: ReactNode): Promise<WhisperInstance> {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+export function renderNewWhisper(element: ReactElement): Promise<WhisperInstance> {
   return render(element, new WhisperRenderInstance());
 }
 

--- a/ldk/javascript/src/whisper/react/whisper-instance-wrapper.ts
+++ b/ldk/javascript/src/whisper/react/whisper-instance-wrapper.ts
@@ -37,7 +37,7 @@ export class WhisperInstanceWrapper implements WhisperInstance {
     this.container = container;
     this.renderInstance = renderInstance;
     this.reconciler = reconciler;
-    this.renderInstance.setOnClose(this.handleWhisperClose);
+    this.renderInstance.setInternalOnClose(this.handleWhisperClose);
   }
 
   close(): void {

--- a/ldk/javascript/src/whisper/react/whisper-render-instance.ts
+++ b/ldk/javascript/src/whisper/react/whisper-render-instance.ts
@@ -21,7 +21,7 @@ export class WhisperRenderInstance implements WhisperRenderingInterface {
 
   private whisper: Whisper | undefined;
 
-  private onCloseHandler: undefined | (() => Promise<void>);
+  private onCloseHandlers: (() => Promise<void>)[] = [];
 
   async createOrUpdateWhisper(whisperData: NewWhisper | UpdateWhisper): Promise<void> {
     if (this.status === RenderInstanceStatus.Closed) {
@@ -48,10 +48,10 @@ export class WhisperRenderInstance implements WhisperRenderingInterface {
 
   handleOnClose = (): void => {
     this.status = RenderInstanceStatus.Closed;
-    this.onCloseHandler?.();
+    this.onCloseHandlers.forEach(handler => handler())
   };
 
   setOnClose(func: () => Promise<void>): void {
-    this.onCloseHandler = func;
+    this.onCloseHandlers.push(func);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "loop-development-kit",
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
@@ -18,6 +19,7 @@
       }
     },
     "docs": {
+      "name": "olive-helps-hub",
       "version": "0.1.0",
       "license": "no license",
       "dependencies": {
@@ -58,7 +60,8 @@
       }
     },
     "ldk/javascript": {
-      "version": "3.7.0",
+      "name": "@oliveai/ldk",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.15.8",


### PR DESCRIPTION
Fixes #473

Added a way for whisper render instances to track and call an internal close handler (used for unmounting stuff) and an external on close handler (for the end user to use).

If you check my previous commit it used a different approach, I think this one is better though.

I also question that `render` and `renderNewWhisper` should take a ReactNode, I think `ReactElement` would be more accurate since the top level component does need to be a `ReactElement`.