### PR TITLE
HELPS-2529-  Update "User Aptitude - JWT - Email Claim" test package.json

### DIFF
--- a/ldk/javascript/examples/self-test-loop/package.json
+++ b/ldk/javascript/examples/self-test-loop/package.json
@@ -47,7 +47,7 @@
       "user": {
         "optionalClaims":[
           {
-            "value" :"team-ldx@oliveai.com"
+            "value" :"email"
           }
         ]
       },

--- a/ldk/javascript/examples/self-test-loop/package.json
+++ b/ldk/javascript/examples/self-test-loop/package.json
@@ -47,10 +47,9 @@
       "user": {
         "optionalClaims":[
           {
-            "value" :"add your email address here"
+            "value" :"team-ldx@oliveai.com"
           }
         ]
-        
       },
       "system": {},
       "screen": {},

--- a/ldk/javascript/examples/self-test-loop/package.json
+++ b/ldk/javascript/examples/self-test-loop/package.json
@@ -44,7 +44,14 @@
       "filesystem": {},
       "process": {},
       "ui": {},
-      "user": {},
+      "user": {
+        "optionalClaims":[
+          {
+            "value" :"add your email address here"
+          }
+        ]
+        
+      },
       "system": {},
       "screen": {},
       "keyboard": {},

--- a/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
@@ -21,6 +21,6 @@ export const userTestGroup = (): TestGroup =>
       'User Aptitude - JWT - Email Claim',
       userTests.testJwtIncludeEmail,
       10000,
-      'Log in to the team-ldx@oliveai.com account in Olive Helps and try this again.',
+      'No action required',
     ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
@@ -21,6 +21,6 @@ export const userTestGroup = (): TestGroup =>
       'User Aptitude - JWT - Email Claim',
       userTests.testJwtIncludeEmail,
       10000,
-      'Please check package.json and update the value of email to your email address!',
+      'Log in to the team-ldx@oliveai.com account in Olive Helps and try this again.',
     ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/user-group.ts
@@ -21,6 +21,6 @@ export const userTestGroup = (): TestGroup =>
       'User Aptitude - JWT - Email Claim',
       userTests.testJwtIncludeEmail,
       10000,
-      'No action required',
+      'Please check package.json and update the value of email to your email address!',
     ),
   ]);


### PR DESCRIPTION
When running the "User Aptitude - JWT - Email Claim" test, the test initiates, but then freezes and never completes.
It turns out that we need to add the `optionalClaims` and add the email address to it.
The permission for user in `package.json` should be like this: 
```

      "user": {
        "optionalClaims": [
          {          
            "value": "email"
          }
        ]
      },
```