### PR TITLE
HELPS-3058 Change stringify to be an array of strings

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
@@ -210,6 +210,12 @@ export const whisperTestGroup = (): TestGroup =>
       'Test the autocomplete',
     ),
     new LoopTest(
+      'Whisper Aptitude - Autocomplete FilterOptions',
+      whisperTests.testAutocompleteFilterOptions,
+      30000,
+      'Test the autocomplete filter options',
+    ),
+    new LoopTest(
       'Whisper Aptitude - Padding',
       whisperTests.testPadding,
       10000,

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -483,7 +483,6 @@ export const testClickableButton = (): Promise<boolean> =>
               label: `Don't click me`,
               onClick: () => console.debug(`Why'd you do that?`),
               type: WhisperComponentType.Button,
-              // size: ButtonSize.Large,
             },
             {
               buttonStyle: ButtonStyle.Text,
@@ -1842,7 +1841,6 @@ export const testSectionTitle = (): Promise<boolean> =>
           {
             body: 'section Title in center',
             type: WhisperComponentType.SectionTitle,
-            // textAlign: TextAlign.Center,
           },
           {
             body: 'section Title on the left',

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -26,12 +26,13 @@ import {
 import { stripIndent } from 'common-tags';
 import {
   autocompleteOptions,
-  filterOptionsTestOptions,
+  ignoreCase,
   createAutocompleteComponent,
   createDivider,
   createTextComponent,
   createSelectComponent,
   logMap,
+  matchFrom,
   resolveRejectButtons,
 } from './utils';
 import { shortText, longText, markdownText, image } from './text';
@@ -482,7 +483,7 @@ export const testClickableButton = (): Promise<boolean> =>
               label: `Don't click me`,
               onClick: () => console.debug(`Why'd you do that?`),
               type: WhisperComponentType.Button,
-              size: ButtonSize.Large,
+              // size: ButtonSize.Large,
             },
             {
               buttonStyle: ButtonStyle.Text,
@@ -1841,7 +1842,7 @@ export const testSectionTitle = (): Promise<boolean> =>
           {
             body: 'section Title in center',
             type: WhisperComponentType.SectionTitle,
-            textAlign: TextAlign.Center,
+            // textAlign: TextAlign.Center,
           },
           {
             body: 'section Title on the left',
@@ -2430,18 +2431,91 @@ export const testAutocomplete = (): Promise<boolean> =>
             options: autocompleteOptions,
             tooltip: 'tooltip',
           },
+        ],
+      });
+    } catch (e) {
+      console.error(e);
+      reject(e);
+    }
+  });
+
+export const testAutocompleteFilterOptions = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    const resolverMap = new Map([
+      ['IgnoreCase', false],
+      ['RespectCase', false],
+      ['Limit', false],
+      ['MatchFromStart', false],
+      ['MatchFromAny', false],
+      ['Stringify', false],
+    ]);
+    try {
+      await whisper.create({
+        label: 'Autocomplete test',
+        onClose: () => {
+          console.debug('closed');
+        },
+        components: [
           {
             type: WhisperComponentType.Markdown,
-            body: 'Select "Value 4"',
+            body: 'Case when searching should be ignored. Search for either "Value" or "value", all options should come back. Select "value 1"',
           },
           {
             type: WhisperComponentType.Autocomplete,
-            label: 'Autocomplete Filter Options Test',
+            label: 'Ignore Case Test',
+            filterOptions: {
+              ignoreCase: true,
+            },
+            loading: false,
+            onChange: () => {
+              // do nothing
+            },
+            onSelect: (error, value, onSelectWhisper) => {
+              console.log(`Received selected value: ${JSON.stringify(value)}`);
+              if (value.includes('1')) {
+                onActionWrapper(error, 'IgnoreCase', resolverMap, onSelectWhisper, resolve, reject);
+              }
+            },
+            options: ignoreCase,
+          },
+          {
+            type: WhisperComponentType.Markdown,
+            body: 'Case when searching should NOT be ignored. Search for either "Value" or "value", only the respective results should come back. Select "value 5"',
+          },
+          {
+            type: WhisperComponentType.Autocomplete,
+            label: `Don't Ignore Case Test`,
             filterOptions: {
               ignoreCase: false,
-              limit: 3,
-              matchFrom: 'start',
-              trim: true,
+            },
+            loading: false,
+            onChange: () => {
+              // do nothing
+            },
+            onSelect: (error, value, onSelectWhisper) => {
+              console.log(`Received selected value: ${JSON.stringify(value)}`);
+              if (value.includes('5')) {
+                onActionWrapper(
+                  error,
+                  'RespectCase',
+                  resolverMap,
+                  onSelectWhisper,
+                  resolve,
+                  reject,
+                );
+              }
+            },
+            options: ignoreCase,
+          },
+          {
+            type: WhisperComponentType.Markdown,
+            body: 'Search results limited to max of 2 options shown. If you click the arrow in other autocompletes and 5 options come back, not setting it works. Select "Value 4"',
+          },
+          {
+            type: WhisperComponentType.Autocomplete,
+            label: 'Limit Test',
+            filterOptions: {
+              limit: 2,
             },
             loading: false,
             onChange: () => {
@@ -2450,10 +2524,90 @@ export const testAutocomplete = (): Promise<boolean> =>
             onSelect: (error, value, onSelectWhisper) => {
               console.log(`Received selected value: ${JSON.stringify(value)}`);
               if (value.includes('4')) {
-                onActionWrapper(error, 'Select', resolverMap, onSelectWhisper, resolve, reject);
+                onActionWrapper(error, 'Limit', resolverMap, onSelectWhisper, resolve, reject);
               }
             },
-            options: filterOptionsTestOptions,
+            options: autocompleteOptions,
+          },
+          {
+            type: WhisperComponentType.Markdown,
+            body: 'The search is searching using matchFrom value "start" (defaults to "any"). This means that the query will try to find items matching from the start of the string. 3 values are "Weird Value X". Start a search with "Weird" and confirm that only those items come back. Then, Search for "Value" and select "Value 2"',
+          },
+          {
+            type: WhisperComponentType.Autocomplete,
+            label: 'Match From Start Test',
+            filterOptions: {
+              matchFrom: 'start',
+            },
+            loading: false,
+            onChange: () => {
+              // do nothing
+            },
+            onSelect: (error, value, onSelectWhisper) => {
+              console.log(`Received selected value: ${JSON.stringify(value)}`);
+              if (value.includes('2')) {
+                onActionWrapper(
+                  error,
+                  'MatchFromStart',
+                  resolverMap,
+                  onSelectWhisper,
+                  resolve,
+                  reject,
+                );
+              }
+            },
+            options: matchFrom,
+          },
+          {
+            type: WhisperComponentType.Markdown,
+            body: 'The search is searching using matchFrom value "any". This means that the query will try to find items matching from any part of the string. Same options as previous Match test. Search "Value", confirm all 5 options return, and select "Value 2"',
+          },
+          {
+            type: WhisperComponentType.Autocomplete,
+            label: 'Match From Any Test',
+            filterOptions: {
+              matchFrom: 'any',
+            },
+            loading: false,
+            onChange: () => {
+              // do nothing
+            },
+            onSelect: (error, value, onSelectWhisper) => {
+              console.log(`Received selected value: ${JSON.stringify(value)}`);
+              if (value.includes('2')) {
+                onActionWrapper(
+                  error,
+                  'MatchFromAny',
+                  resolverMap,
+                  onSelectWhisper,
+                  resolve,
+                  reject,
+                );
+              }
+            },
+            options: matchFrom,
+          },
+          {
+            type: WhisperComponentType.Markdown,
+            body: `Uses the stringify function in filter options. This tells the autocomplete to use a different value when searching it's options. In this case, it is using option.value (1, 2, 3, 4, 5) instead of option.label. This means that if you search "Value", noting will return. Confirm that this happens, then search 1, confirm it shows up, then select "Value 1"`,
+          },
+          {
+            type: WhisperComponentType.Autocomplete,
+            label: 'Stringify Test',
+            filterOptions: {
+              stringify: ['value'],
+            },
+            loading: false,
+            onChange: () => {
+              // do nothing
+            },
+            onSelect: (error, value, onSelectWhisper) => {
+              console.log(`Received selected value: ${JSON.stringify(value)}`);
+              if (value.includes('1')) {
+                onActionWrapper(error, 'Stringify', resolverMap, onSelectWhisper, resolve, reject);
+              }
+            },
+            options: autocompleteOptions,
           },
         ],
       });

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/utils.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/utils.ts
@@ -174,11 +174,18 @@ export const autocompleteOptions = [
   { label: 'Value 4', value: '4' },
   { label: 'Value 5', value: '5' },
 ];
-export const filterOptionsTestOptions = [
-  { label: 'THIS IS ALL CAPS', value: '1' },
-  { label: 'this is all lower', value: '2' },
-  { label: 'Ending with Olive', value: '3' },
-  { label: 'Olive starts here', value: '4' },
-  { label: 'Middle Olive here', value: '5' },
-  { label: 'Trailing Spaces           ', value: '6' },
+export const ignoreCase = [
+  { label: 'value 1', value: '1' },
+  { label: 'Value 2', value: '2' },
+  { label: 'value 3', value: '3' },
+  { label: 'Value 4', value: '4' },
+  { label: 'value 5', value: '5' },
+];
+
+export const matchFrom = [
+  { label: 'Weird Value 1', value: '1' },
+  { label: 'Value 2', value: '2' },
+  { label: 'Weird Value 3', value: '3' },
+  { label: 'Value 4', value: '4' },
+  { label: 'Weird Value 5', value: '5' },
 ];

--- a/ldk/javascript/src/types/oliveHelps/whisper.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/whisper.d.ts
@@ -114,7 +114,7 @@ declare namespace WhisperService {
 
   type AutocompleteOption = {
     label: string;
-    value: any;
+    value: any; // eslint-disable-line
   };
 
   interface AutocompleteFilterOptions {

--- a/ldk/javascript/src/types/oliveHelps/whisper.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/whisper.d.ts
@@ -114,7 +114,7 @@ declare namespace WhisperService {
 
   type AutocompleteOption = {
     label: string;
-    value: string;
+    value: any;
   };
 
   interface AutocompleteFilterOptions {
@@ -122,7 +122,7 @@ declare namespace WhisperService {
     ignoreCase?: boolean;
     limit?: number;
     matchFrom?: 'any' | 'start';
-    stringify?: (option: AutocompleteOption) => void;
+    stringify?: string[];
     trim?: boolean;
   }
 

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -75,17 +75,17 @@ export enum WhisperComponentType {
    */
   TextInput = 'textInput',
   /**
-   * The section title field allows the user to provide section title information.
+   * The SectionTitle component adds a background that stretches across the entire whisper to the provided text
    */
   SectionTitle = 'sectionTitle',
   /**
-   The text input field allows the user to provide Date and Time information.
+   * A text input field allows the user to provide date and time information.
    *
    * The field can be pre-populated by the loop.
    */
   DateTimeInput = 'dateTimeInput',
   /**
-   *  The richText Editor allow users to use RichText Editor on Olive Helps
+   *  The RichTextEditor gives users a text area that allows users to add text with styling (bold, italics, links, etc)
    */
   RichTextEditor = 'richTextEditor',
   /**
@@ -93,7 +93,7 @@ export enum WhisperComponentType {
    */
   Icon = 'icon',
   /**
-   * The dropzone component allows the Loop to receive
+   * The dropzone component allows the Loop to receive a file uploaded by a user
    */
   DropZone = 'dropZone',
 }

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -202,7 +202,7 @@ export enum IconSize {
 
 export type AutocompleteOption = {
   label: string;
-  value: string;
+  value: any;
 };
 
 export enum ProgressShape {
@@ -293,9 +293,11 @@ export interface AutocompleteFilterOptions {
   matchFrom?: 'any' | 'start';
   /**
    * Controls how an option is converted into a string so that
-   * it can be matched against the input text fragment.
+   * it can be matched against the input text fragment. Accepts
+   * an array of strings that is the path to the key in the
+   * AutocompleteOption to be used.
    */
-  stringify?: (option: AutocompleteOption) => void;
+  stringify?: string[];
   /**
    * Defaults to false. Remove trailing spaces.
    */

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -202,7 +202,7 @@ export enum IconSize {
 
 export type AutocompleteOption = {
   label: string;
-  value: any;
+  value: any; // eslint-disable-line;
 };
 
 export enum ProgressShape {

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -202,7 +202,7 @@ export enum IconSize {
 
 export type AutocompleteOption = {
   label: string;
-  value: any; // eslint-disable-line;
+  value: any; // eslint-disable-line
 };
 
 export enum ProgressShape {


### PR DESCRIPTION
- Fixes a type error with `filterOptions.stringify` to make it inline with OH.
- Adds a test to self test loop to excercise `filteerOptions`
- Modifies FilterOption.value to be `any` rather than `string`