### PR TITLE
Add prop href to Button and Icon component 

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
@@ -300,4 +300,10 @@ export const whisperTestGroup = (): TestGroup =>
       10000,
       'Does box pass on after clicking the breadcrumb link?',
     ),
+    new LoopTest(
+      'Whisper Aptitude - Icon and Button href test',
+      whisperTests.testButtonAndIconHref,
+      10000,
+      'Click the button and icon and chceck if they can redirect you to the website',
+    ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -3339,3 +3339,28 @@ export const testBreadcrumbUpdateBox = (): Promise<boolean> =>
       components: [bread],
     });
   });
+
+export const testButtonAndIconHref = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    await whisper.create({
+      label: 'Can Icon and Button direct you to the website? ',
+      onClose: () => {
+        console.debug('closed');
+      },
+      components: [
+        {
+          type: WhisperComponentType.Icon,
+          name: 'Icon1',
+          href: 'https://www.google.com',
+        },
+        {
+          type: WhisperComponentType.Button,
+          href: 'https://www.google.com',
+          onClick: () => {
+            console.log('Button clicked');
+          },
+        },
+        resolveRejectButtons(resolve, reject, 'Yes', 'No', true),
+      ],
+    });
+  });

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -400,6 +400,7 @@ export type Breadcrumbs = WhisperComponent<WhisperComponentType.Breadcrumbs> & {
 
 export type Button = WhisperComponent<WhisperComponentType.Button> & {
   buttonStyle?: ButtonStyle;
+  href?: string;
   disabled?: boolean;
   label?: string;
   onClick: WhisperHandler;
@@ -478,6 +479,7 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
 
 export type Icon = WhisperComponent<WhisperComponentType.Icon> & {
   name: string;
+  href?: string;
   size?: IconSize;
   color?: Color.Black | Color.Grey | Color.White | Color.WhisperStrip;
   onClick?: WhisperHandler;


### PR DESCRIPTION
User requested that the `Button` and `Icon` components allow an href prop be passed.

- Button and Icon components take in href prop, similar to the Link component
- Button and Icon components can be used with the href prop to open files, similar to the Link component
- Create self test `testButtonAndIconHref`