### PR TITLE
Add Icons to Button component

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/whisper-group.ts
@@ -312,4 +312,10 @@ export const whisperTestGroup = (): TestGroup =>
       10000,
       'Does box pass on after clicking the breadcrumb link?',
     ),
+    new LoopTest(
+      'Whisper Aptitude - Test ButtonIcon',
+      whisperTests.testButtonIcon,
+      10000,
+      'Are the icon buttons clickable?',
+    ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -11,6 +11,7 @@ import {
   Direction,
   JustifyContent,
   IconSize,
+  IconVariant,
   MessageWhisperCopyMode,
   MarkdownWhisperCopyMode,
   NewWhisper,
@@ -3552,5 +3553,54 @@ export const testBreadcrumbUpdateBox = (): Promise<boolean> =>
         console.debug('closed');
       },
       components: [bread],
+    });
+  });
+
+export const testButtonIcon = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    await whisper.create({
+      label: 'Are the icon buttons clickable?',
+      onClose: () => {
+        console.debug('closed');
+      },
+      components: [
+        {
+          type: WhisperComponentType.Button,
+          onClick: () => {
+            console.log('button clicked.');
+          },
+          startIcon: {
+            name: 'call',
+            variant: IconVariant.Round,
+          },
+          endIcon: {
+            name: 'pets',
+            variant: IconVariant.Outlined,
+          },
+        },
+        {
+          type: WhisperComponentType.Button,
+          onClick: () => {
+            console.log('article button clicked.');
+          },
+          label: 'article button',
+          startIcon: {
+            name: 'article',
+            variant: IconVariant.Sharp,
+          },
+        },
+        {
+          type: WhisperComponentType.Button,
+          onClick: () => {
+            console.log('emoji button clicked.');
+          },
+          label: 'emoji button',
+          endIcon: {
+            name: 'emoji_emotions',
+            variant: IconVariant.TwoTone,
+          },
+        },
+        resolveRejectButtons(resolve, reject, 'Yes', 'No', true),
+      ],
     });
   });

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -233,13 +233,6 @@ export enum StyleSize {
   Medium = 'medium',
   Large = 'large',
 }
-export enum IconVariant {
-  Outlined = 'outlined',
-  Round = 'round',
-  Sharp = 'sharp',
-  TwoTone = 'two-tone',
-}
-
 export enum WidthSize {
   Full = 'full',
   Half = 'half',

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -409,11 +409,11 @@ export type Breadcrumbs = WhisperComponent<WhisperComponentType.Breadcrumbs> & {
 export type Button = WhisperComponent<WhisperComponentType.Button> & {
   endIcon?: {
     name: string;
-    variant: IconVariant;
+    variant?: IconVariant;
   };
   startIcon?: {
     name: string;
-    variant: IconVariant;
+    variant?: IconVariant;
   };
   buttonStyle?: ButtonStyle;
   disabled?: boolean;

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -233,6 +233,7 @@ export enum StyleSize {
   Medium = 'medium',
   Large = 'large',
 }
+
 export enum WidthSize {
   Full = 'full',
   Half = 'half',

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -215,6 +215,12 @@ export enum StyleSize {
   Medium = 'medium',
   Large = 'large',
 }
+export enum IconVariant {
+  Outlined = 'outlined',
+  Round = 'round',
+  Sharp = 'sharp',
+  TwoTone = 'two-tone',
+}
 
 export enum WidthSize {
   Full = 'full',
@@ -401,6 +407,14 @@ export type Breadcrumbs = WhisperComponent<WhisperComponentType.Breadcrumbs> & {
 };
 
 export type Button = WhisperComponent<WhisperComponentType.Button> & {
+  endIcon?: {
+    name: string;
+    variant: IconVariant;
+  };
+  startIcon?: {
+    name: string;
+    variant: IconVariant;
+  };
   buttonStyle?: ButtonStyle;
   disabled?: boolean;
   label?: string;


### PR DESCRIPTION
1. Add startIcon and endIcon to Button component. They are optional props.
2.  startIcon appears at the start of button's label, endIcon appears at the end of button's label.
3.  IconVariant is also supported with startIcon and endIcon

<img width="377" alt="Screen Shot 2022-01-20 at 12 52 05 PM" src="https://user-images.githubusercontent.com/84045424/150394514-d63d89c5-1078-4087-9201-68deed1fee78.png">
