### PR TITLE
HELPS-1931: Icon does not accept Accent color

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -109,7 +109,7 @@ export const testIconLayout = (): Promise<boolean> =>
               type: WhisperComponentType.Icon,
               name: 'fingerprint',
               size: IconSize.Large,
-              color: Color.Black,
+              color: Color.Accent,
               onClick: () => {
                 console.info('Fingerprint Clicked');
               },

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -566,7 +566,7 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
 export type Icon = WhisperComponent<WhisperComponentType.Icon> & {
   name: string;
   size?: IconSize;
-  color?: Color.Black | Color.Grey | Color.White | Color.WhisperStrip;
+  color?: Color.Black | Color.Grey | Color.White | Color.WhisperStrip | Color.Accent;
   onClick?: WhisperHandler;
   tooltip?: string;
   variant?: IconVariant;


### PR DESCRIPTION
[HELPS-1931](https://crosschx.atlassian.net/browse/HELPS-1931)

* Added `Accent` as an accepted color for `Icon` component