### PR TITLE
Helps 3411 listenOcrMonitor

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/config/screen-group.ts
+++ b/ldk/javascript/examples/self-test-loop/src/config/screen-group.ts
@@ -35,4 +35,10 @@ export const screenTestGroup = (): TestGroup =>
       10000,
       'Please open a new fullscreen window and change the contents (A browser works well for this).',
     ),
+    new LoopTest(
+      'Screen Aptitude - Listen OCR Monitor',
+      screenTests.testScreenMonitor,
+      10000,
+      'Please check if New Text and Old Text are different.',
+    ),
   ]);

--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-async-promise-executor */
 import { screen, whisper, window } from '@oliveai/ldk';
-
 export * from './hashTests';
 
 const writeWhisper = (label: string, body: string) =>
@@ -109,3 +108,48 @@ export async function performOcr() {
       });
   });
 }
+
+export const testScreenMonitor = (): Promise<boolean> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      console.log('Running listenOcrMonitor function...');
+      sleep(1000);
+      const listener = await screen.listenOcrMonitor((ocrEvent) => {
+        sleep(1000);
+        // eslint-disable-next-line @typescript-eslint/no-array-constructor
+        const resultNew = new Array();
+        // eslint-disable-next-line @typescript-eslint/no-array-constructor
+        const resultOld = new Array();
+
+        ocrEvent.forEach((element) => {
+          resultNew.push(element.new.text);
+          resultOld.push(element.old.text);
+        });
+
+        const resultNewString = resultNew.join(' ');
+        const resultOldString = resultOld.join(' ');
+        whisper.create({
+          label: 'test Screen Monitor',
+          onClose: () => {
+            console.log(`Closed Whisper`);
+          },
+          components: [
+            {
+              body: `New Text: ${resultNewString}`,
+              type: whisper.WhisperComponentType.Markdown,
+            },
+            {
+              body: `Old Text: ${resultOldString}`,
+              type: whisper.WhisperComponentType.Markdown,
+            },
+          ],
+        });
+        console.log('result of changed text are', resultNewString);
+        listener.cancel();
+      });
+
+      resolve(true);
+    } catch (error) {
+      reject(error);
+    }
+  });

--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-async-promise-executor */
 import { screen, whisper, window } from '@oliveai/ldk';
+import { OcrEvent } from '@oliveai/ldk/dist/screen/types';
 export * from './hashTests';
 
 const writeWhisper = (label: string, body: string) =>
@@ -114,12 +115,11 @@ export const testScreenMonitor = (): Promise<boolean> =>
     try {
       console.log('Running listenOcrMonitor function...');
       sleep(1000);
+
       const listener = await screen.listenOcrMonitor((ocrEvent) => {
         sleep(1000);
-        // eslint-disable-next-line @typescript-eslint/no-array-constructor
-        const resultNew = new Array();
-        // eslint-disable-next-line @typescript-eslint/no-array-constructor
-        const resultOld = new Array();
+        const resultNew: string[] = [];
+        const resultOld: string[] = [];
 
         ocrEvent.forEach((element) => {
           resultNew.push(element.new.text);
@@ -146,9 +146,8 @@ export const testScreenMonitor = (): Promise<boolean> =>
         });
         console.log('result of changed text are', resultNewString);
         listener.cancel();
+        resolve(true);
       });
-
-      resolve(true);
     } catch (error) {
       reject(error);
     }

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -1,12 +1,13 @@
 import { Cancellable } from '../cancellable';
 import {
+  promisifyListenable,
   promisifyListenableWithFourParams,
   promisifyListenableWithThreeParams,
   promisifyListenableWithTwoParams,
   promisifyWithParam,
   promisifyWithTwoParams,
 } from '../promisify';
-import { Bounds, HashType, OCRResult, OCRCoordinates } from './types';
+import { Bounds, HashType, OCRResult, OCRCoordinates, OcrEvent } from './types';
 
 export * from './types';
 
@@ -86,6 +87,12 @@ export interface Screen {
     delayMs: number,
     callback: (difference: number) => void,
   ): Promise<Cancellable>;
+  /**
+   * @experimental This functionality is experimental and subject to breaking changes.
+   * listenOcrMonitor listens to active window changes.
+   * @param ocrEvents - The event that records ounds and text changes.
+   */
+  listenOcrMonitor(callback: (ocrEvents: OcrEvent[]) => void): Promise<Cancellable>;
 }
 
 export function ocr(ocrCoordinates: OCRCoordinates): Promise<OCRResult[]> {
@@ -168,4 +175,7 @@ export function listenPixelDiffActiveWindow(
     callback,
     oliveHelps.screen.listenPixelDiffActiveWindow,
   );
+}
+export function listenOcrMonitor(callback: (ocrEvents: OcrEvent[]) => void): Promise<Cancellable> {
+  return promisifyListenable(callback, oliveHelps.screen.listenOcrMonitor);
 }

--- a/ldk/javascript/src/screen/index.ts
+++ b/ldk/javascript/src/screen/index.ts
@@ -89,8 +89,8 @@ export interface Screen {
   ): Promise<Cancellable>;
   /**
    * @experimental This functionality is experimental and subject to breaking changes.
-   * listenOcrMonitor listens to active window changes.
-   * @param ocrEvents - The event that records ounds and text changes.
+   * listenOcrMonitor listens to active window changes. This function provides active window recognition on the backend.
+   * @param ocrEvents - The event that records bounds and text changes.
    */
   listenOcrMonitor(callback: (ocrEvents: OcrEvent[]) => void): Promise<Cancellable>;
 }

--- a/ldk/javascript/src/screen/screen.test.ts
+++ b/ldk/javascript/src/screen/screen.test.ts
@@ -15,6 +15,7 @@ describe('screen', () => {
       listenPerceptionHash: jest.fn(),
       listenPixelDiff: jest.fn(),
       listenPixelDiffActiveWindow: jest.fn(),
+      listenOcrMonitor: jest.fn(),
     };
   });
   describe('ocr', () => {
@@ -55,6 +56,29 @@ describe('screen', () => {
       });
 
       expect(screen.ocr).rejects.toBe(exception);
+    });
+  });
+  describe('listenOcrMonitor', () => {
+    it('return a promise of ocrEvent', () => {
+      // eslint-disable-next-line @typescript-eslint/no-array-constructor
+      const resultArray = new Array();
+      // eslint-disable-next-line @typescript-eslint/no-array-constructor
+      const theArray = new Array();
+      screen.listenOcrMonitor((result) => {
+        result.forEach((element) => {
+          resultArray.push(element.new.text);
+        });
+      });
+      expect(theArray).toStrictEqual(resultArray);
+    });
+
+    it('rejects with the error when the underlying call throws an error', () => {
+      const exception = 'Exception';
+      mocked(oliveHelps.screen.listenOcrMonitor).mockImplementation(() => {
+        throw exception;
+      });
+
+      expect(screen.listenOcrMonitor).rejects.toBe(exception);
     });
   });
 });

--- a/ldk/javascript/src/screen/types.ts
+++ b/ldk/javascript/src/screen/types.ts
@@ -33,3 +33,23 @@ export enum HashType {
   Difference,
   Perception,
 }
+
+export interface OcrEvent {
+  old: TextAndBounds;
+  new: TextAndBounds;
+}
+
+export interface TextAndBounds {
+  bounds: Rectangle;
+  text: string;
+}
+
+export type Rectangle = {
+  Max: Point;
+  Min: Point;
+};
+
+export type Point = {
+  X: number;
+  Y: number;
+};

--- a/ldk/javascript/src/types/oliveHelps/screen.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/screen.d.ts
@@ -11,6 +11,7 @@ declare namespace Screen {
     listenPerceptionHash: Common.ListenableWithFourParams<Bounds, number, number, number, number>;
     listenPixelDiff: Common.ListenableWithThreeParams<Bounds, number, number, number>;
     listenPixelDiffActiveWindow: Common.ListenableWithTwoParams<number, number, number>;
+    listenOcrMonitor: Common.Listenable<OcrEvent[]>;
   }
 
   interface OCRResult {
@@ -34,11 +35,30 @@ declare namespace Screen {
     width: number;
     height: number;
   }
+  interface OcrEvent {
+    old: TextAndBounds;
+    new: TextAndBounds;
+  }
+
+  interface TextAndBounds {
+    bounds: Rectangle;
+    text: string;
+  }
 
   type Bounds = {
     top: number;
     left: number;
     width: number;
     height: number;
+  };
+
+  type Rectangle = {
+    Max: Point;
+    Min: Point;
+  };
+
+  type Point = {
+    X: number;
+    Y: number;
   };
 }


### PR DESCRIPTION
- Implement new exposed method for loop author to listen to ocr monitor 

- This will listen to active window changes
- This function provides active window recognition in the backend
- Users can run multiple `listenOcrMonitor` function at the same time to get better ocr accuracy.

![Screen Shot 2022-02-24 at 5 16 43 PM](https://user-images.githubusercontent.com/84045424/155617180-f10966f7-ea96-4ccd-91a8-859fb5b555c1.png)


