### PR TITLE
Helps 2930 Customize DropZone component text

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -400,11 +400,12 @@ export const testDropzone = async (): Promise<boolean> => {
   const dropZone: whisper.DropZone = {
     type: WhisperComponentType.DropZone,
     onDrop: () => {},
+    limit: 3,
     messaging: {
-      accept: 'file accepted',
-      click: 'dropzone clicked',
-      drop: 'file dropped',
-      limit: 'reached ',
+      accept: 'That file type is not accepted',
+      click: 'BROWSE',
+      drop: 'drop here',
+      limit: 'You can only upload 3 files ',
     },
     label: 'File Components',
     key: 'drop',

--- a/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/whisper/index.ts
@@ -400,6 +400,12 @@ export const testDropzone = async (): Promise<boolean> => {
   const dropZone: whisper.DropZone = {
     type: WhisperComponentType.DropZone,
     onDrop: () => {},
+    messaging: {
+      accept: 'file accepted',
+      click: 'dropzone clicked',
+      drop: 'file dropped',
+      limit: 'reached ',
+    },
     label: 'File Components',
     key: 'drop',
   };

--- a/ldk/javascript/src/types/oliveHelps/whisper.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/whisper.d.ts
@@ -156,6 +156,12 @@ declare namespace WhisperService {
     accept?: string[];
     label: string;
     limit?: number;
+    messaging?: {
+      accept?: string;
+      click?: string;
+      drop?: string;
+      limit?: string;
+    };
     noun?: string;
     onDrop: WhisperHandlerWithParam<File[]>;
     value?: File[];

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -461,6 +461,15 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
    */
   noun?: string;
   /**
+   * If provided, display the messages stating that the the file being accepted, user drops a file, click a file, has reached the maximum number of files.
+   */
+  messaging?: {
+    accept?: string;
+    click?: string;
+    drop?: string;
+    limit?: string;
+  };
+  /**
    * The callback function to call whenever the user selects or unselects a file.
    */
   onDrop: WhisperHandlerWithParam<File[]>;

--- a/ldk/javascript/src/whisper/types.ts
+++ b/ldk/javascript/src/whisper/types.ts
@@ -461,7 +461,7 @@ export type DropZone = WhisperComponent<WhisperComponentType.DropZone> & {
    */
   noun?: string;
   /**
-   * If provided, display the messages stating that the the file being accepted, user drops a file, click a file, has reached the maximum number of files.
+   * If provided, display the messages stating that the the file not being accepted, the area that user drops a file, browse a file, or has reached the maximum number of files.
    */
   messaging?: {
     accept?: string;


### PR DESCRIPTION
- Add ability to change the display text stating that 

1. the the file not being accepted
2. the area that user drops a file
3.  browse a file
4.  has reached the maximum number of files.

<img width="390" alt="Screen Shot 2022-02-22 at 12 23 40 PM" src="https://user-images.githubusercontent.com/84045424/155185212-414730e6-7503-4a2d-b6ae-adf3152b06ae.png">
