### PR TITLE
HELPS-3575: Browser aptitude self tests failing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## [HELPS-XXXX](https://crosschx.atlassian.net/browse/HELPS-XXXX)
+
+### Changes made:
+
+- Bullet
+- Points
+
+### Additional notes:

--- a/ldk/javascript/examples/self-test-loop/src/tests/browser/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/browser/index.ts
@@ -6,13 +6,11 @@ export const testOpenTabAndListenNavigation = (): Promise<boolean> =>
   new Promise(async (resolve, reject) => {
     try {
       const URL = 'https://www.oliveai.dev/';
-      const tabId = await browser.openTab(URL);
-
       const listener = await browser.listenNavigation(
         (navigationEvent: NavigationDetails): void => {
-          const { tabId: eventTabId, url: eventUrl } = navigationEvent;
+          const { url: eventUrl } = navigationEvent;
 
-          if (eventTabId === tabId && eventUrl === URL) {
+          if (eventUrl === URL) {
             listener.cancel();
             resolve(true);
           }
@@ -20,6 +18,8 @@ export const testOpenTabAndListenNavigation = (): Promise<boolean> =>
           reject(new Error('The newest tab and URL do not match the test'));
         },
       );
+
+      await browser.openTab(URL);
     } catch (error) {
       console.error(error);
       reject(error);
@@ -116,8 +116,6 @@ export const testOpenWindowAndListenNavigation = (): Promise<boolean> =>
   new Promise(async (resolve, reject) => {
     try {
       const URL = 'https://www.oliveai.dev/';
-      await browser.openWindow(URL);
-
       const listener = await browser.listenNavigation(
         (navigationEvent: NavigationDetails): void => {
           const { url: eventUrl } = navigationEvent;
@@ -131,6 +129,8 @@ export const testOpenWindowAndListenNavigation = (): Promise<boolean> =>
           reject(new Error('The URL opened in the window does not match the test URL'));
         },
       );
+
+      await browser.openWindow(URL);
     } catch (error) {
       console.error(error);
       reject(error);


### PR DESCRIPTION
## [HELPS-3575](https://crosschx.atlassian.net/browse/HELPS-3575)

### Changes made:

- Fixed bug where Browser aptitude navigation stream self tests were failing because listener was started after openTab/openWindow functions were run
- Added a PR template

### Additional notes: