### PR TITLE
HELPS-4307 Update LDK GitHub Issues to use Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: 'Status: Needs Investigation, Type: Bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows 10]
+ - LDK Version: [e.g. 3.5.1]
+ - Olive Helps Version: [e.g. 0.40.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: 'Status: Needs Investigation, Type: Feature Request'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
We need to get better info when issues are created. Rather than a blank form, there are 2 types to choose from with different templates for each.

These templates were created via GitHub's GUI editor, so I "trust" the syntax.