### PR TITLE
HELPS-4347 return after reject

### DIFF
--- a/ldk/javascript/src/network/mapper.ts
+++ b/ldk/javascript/src/network/mapper.ts
@@ -121,6 +121,7 @@ export const mapToSocket = (socket: Network.Socket): Socket => ({
           if (error) {
             console.error(`Received error on ping ${error.message}`);
             reject(error);
+            return;
           }
           resolve();
         });

--- a/ldk/javascript/src/whisper/index.ts
+++ b/ldk/javascript/src/whisper/index.ts
@@ -26,6 +26,7 @@ export function create(whisper: NewWhisper): Promise<Whisper> {
         (error: Error | undefined, internalWhisper: WhisperService.Whisper) => {
           if (error) {
             reject(error);
+            return;
           }
           resolve(mapToExternalWhisper(internalWhisper, stateMap));
         },


### PR DESCRIPTION
## [HELPS-4347](https://crosschx.atlassian.net/browse/HELPS-4347)

### Changes made:

- Add return statement after rejecting a promise to stop function execution
- Add test cases for network websocket

### Additional notes:
