### PR TITLE
Helps- 4624 Changed `conf` to `confidence`

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/screen/index.ts
@@ -155,7 +155,8 @@ export async function performOcrFileEncoded() {
     .then((result) => {
       console.log('OCR Results: ');
       console.log(JSON.stringify(result));
-      const concatResult = result.map((res) => res.text).join(' ');
+      const filteredResult = result.filter((e) => e.confidence > 75);
+      const concatResult = filteredResult.map((res) => res.text).join(' ');
       console.log('concatResult', concatResult);
       writeWhisperFileEncodedResult('result', concatResult);
     })

--- a/ldk/javascript/src/document/document.test.ts
+++ b/ldk/javascript/src/document/document.test.ts
@@ -132,7 +132,7 @@ describe('Document', () => {
           top: 1,
           width: 1,
           height: 1,
-          conf: 1,
+          confidence: 1,
           text: 'test',
         },
       ];

--- a/ldk/javascript/src/screen/screen.test.ts
+++ b/ldk/javascript/src/screen/screen.test.ts
@@ -39,7 +39,7 @@ describe('screen', () => {
           top: 1,
           width: 1,
           height: 1,
-          conf: 1,
+          confidence: 1,
           text: '',
         },
       ];
@@ -96,7 +96,7 @@ describe('screen', () => {
           top: 1,
           width: 1,
           height: 1,
-          conf: 1,
+          confidence: 1,
           text: '',
         },
       ];

--- a/ldk/javascript/src/screen/types.ts
+++ b/ldk/javascript/src/screen/types.ts
@@ -10,7 +10,7 @@ export interface OCRResult {
   top: number;
   width: number;
   height: number;
-  conf: number;
+  confidence: number;
   text: string;
 }
 

--- a/ldk/javascript/src/types/oliveHelps/screen.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/screen.d.ts
@@ -26,7 +26,7 @@ declare namespace Screen {
     top: number;
     width: number;
     height: number;
-    conf: number;
+    confidence: number;
     text: string;
   }
 


### PR DESCRIPTION
## [HELPS-4624](https://crosschx.atlassian.net/browse/HELPS-4624)

### Changes made:
- Updated ocrResult's prop `conf` to `confidence`. 
- Updated Self Test Loop accordingly. 
### Additional notes:
