### PR TITLE
Helps-4640 Added email to jwtWithUserDetails and updated test

### DIFF
--- a/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
+++ b/ldk/javascript/examples/self-test-loop/src/tests/user/index.ts
@@ -108,6 +108,10 @@ export const testJwtUserDetailsIncludeEmail = (): Promise<boolean> =>
               body: 'The email claim is still in the encoded text. You can paste the token into jwt.io to check the claims. This token **should** have an email claim.',
             },
             {
+              type: whisper.WhisperComponentType.Markdown,
+              body: `The email is ${token.email}`,
+            },
+            {
               type: whisper.WhisperComponentType.Link,
               text: 'Click here to copy the JWT to your clipboard.',
               onClick: async () => {

--- a/ldk/javascript/src/types/oliveHelps/user.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/user.d.ts
@@ -16,6 +16,7 @@ declare namespace User {
   }
 
   interface JWTWithUserDetails {
+    email?: string;
     fullName?: string;
     jwt: string;
     organizationId?: string;

--- a/ldk/javascript/src/user/index.ts
+++ b/ldk/javascript/src/user/index.ts
@@ -20,6 +20,7 @@ export interface JWTWithUserDetailsConfig {
 }
 
 export interface JWTWithUserDetails {
+  email?: string;
   fullName?: string;
   jwt: string;
   organizationId?: string;

--- a/ldk/javascript/src/user/user.test.ts
+++ b/ldk/javascript/src/user/user.test.ts
@@ -56,6 +56,7 @@ describe('User', () => {
       const jwt = {
         jwt: 'jwt',
         organizationId: 'stuff',
+        email: 'a@g.com',
       };
       mocked(oliveHelps.user.jwtWithUserDetails).mockImplementation((unknow: unknown, callback) =>
         callback(undefined, jwt),
@@ -76,6 +77,7 @@ describe('User', () => {
       const jwt = {
         jwt: 'jwt',
         organizationName: 'stuff',
+        email: 'a@g.com',
       };
       mocked(oliveHelps.user.jwtWithUserDetails).mockImplementation((unknow: unknown, callback) =>
         callback(undefined, jwt),


### PR DESCRIPTION
## [HELPS-4640](https://crosschx.atlassian.net/browse/HELPS-4640)

### Changes made:

- Added `email` to `jwtWithUserDetails`
- Updated test accordingly

### Additional notes:
<img width="375" alt="Screen Shot 2022-05-12 at 1 30 18 PM" src="https://user-images.githubusercontent.com/84045424/168134778-20db432b-e985-404a-9e0b-9bc1179c5789.png">
 