### PR TITLE
HELPS-4627 Update LDK Webpack to Not Cache package.json

### DIFF
--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "clear-dist": "rm -rf dist || del /s /q dist",
+    "compile": "tsc",
     "build": "npm run clear-dist && tsc",
     "prepush": "npm run build && npm run test && npm run lint",
     "test": "jest",

--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "3.17.0",
   "description": "The Loop Development Kit for Olive Helps.",
   "author": "Olive",
-  "copyright": "Copyright 2021 Olive",
+  "copyright": "Copyright 2022 Olive",
   "homepage": "https://github.com/open-olive/loop-development-kit#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -17,9 +17,9 @@
     "sdk"
   ],
   "scripts": {
-    "clear-dist": "rm -rf dist || del /s /q dist",
+    "build": "npm run clear-dist && npm run compile",
     "compile": "tsc",
-    "build": "npm run clear-dist && tsc",
+    "clear-dist": "rm -rf dist || del /s /q dist",
     "prepush": "npm run build && npm run test && npm run lint",
     "test": "jest",
     "test-coverage": "jest --collectCoverage",

--- a/ldk/javascript/package.json
+++ b/ldk/javascript/package.json
@@ -2,8 +2,10 @@
   "name": "@oliveai/ldk",
   "version": "3.17.0",
   "description": "The Loop Development Kit for Olive Helps.",
-  "author": "Olive",
-  "copyright": "Copyright 2022 Olive",
+  "author": {
+    "name": "Olive AI, Inc."
+  },
+  "copyright": "Copyright (C) 2022 Olive AI, Inc. All rights reserved.",
   "homepage": "https://github.com/open-olive/loop-development-kit#readme",
   "license": "MIT",
   "main": "dist/index.js",

--- a/ldk/javascript/src/webpack/config.development.ts
+++ b/ldk/javascript/src/webpack/config.development.ts
@@ -1,21 +1,18 @@
-import * as webpack from 'webpack';
-import * as path from 'path';
-import { LdkSettings } from './ldk-settings';
+import { join as joinPath } from 'path';
+import { Configuration as WebpackConfiguration, RuleSetRule } from 'webpack';
+
+import { generateLdkSettings } from './generate-ldk-settings';
 import { buildBabelConfig, buildOptimization, buildWebpackConfig } from './shared';
 
-// Need to dynamically refer to Loop's package.json
-// Suppressing rule as we intentionally want a dynamic require.
-// eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require
-const ldkSettings: LdkSettings = require(path.join(process.cwd(), '/package.json'));
-const baseBabelConfig: webpack.RuleSetRule = buildBabelConfig(true);
+const baseBabelConfig: RuleSetRule = buildBabelConfig(true);
 const optimization = buildOptimization(false);
-const buildPath = path.join(process.cwd(), 'dist');
+const buildPath = joinPath(process.cwd(), 'dist');
 
-const config: webpack.Configuration = buildWebpackConfig(
+const config: WebpackConfiguration = buildWebpackConfig(
   buildPath,
   baseBabelConfig,
   optimization,
-  ldkSettings,
+  generateLdkSettings,
 );
 
 export default config;

--- a/ldk/javascript/src/webpack/config.ts
+++ b/ldk/javascript/src/webpack/config.ts
@@ -1,19 +1,18 @@
-import * as webpack from 'webpack';
-import * as path from 'path';
-import { LdkSettings } from './ldk-settings';
-import { buildBabelConfig, buildOptimization, buildWebpackConfig } from './shared';
+import { join as joinPath } from 'path';
+import { Configuration as WebpackConfiguration, RuleSetRule } from 'webpack';
+
 import { generateLdkSettings } from './generate-ldk-settings';
+import { buildBabelConfig, buildOptimization, buildWebpackConfig } from './shared';
 
-const ldkSettings: LdkSettings = generateLdkSettings();
-const baseBabelConfig: webpack.RuleSetRule = buildBabelConfig(false);
+const baseBabelConfig: RuleSetRule = buildBabelConfig(false);
 const optimization = buildOptimization(true);
-const buildPath = path.join(process.cwd(), 'dist');
+const buildPath = joinPath(process.cwd(), 'dist');
 
-const config: webpack.Configuration = buildWebpackConfig(
+const config: WebpackConfiguration = buildWebpackConfig(
   buildPath,
   baseBabelConfig,
   optimization,
-  ldkSettings,
+  generateLdkSettings,
 );
 
 export default config;

--- a/ldk/javascript/src/webpack/generate-ldk-settings.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.ts
@@ -19,13 +19,7 @@ export function mergeLdkSettings(
 export function generateLdkSettings(): LdkSettings {
   // Need to dynamically refer to Loop's package.json (from cwd).
   let ldkSettings: LdkSettings = JSON.parse(
-    readFileSync(
-      joinPath(
-        process.cwd(),
-        'package.json'
-      ),
-      { encoding: 'utf8', flag: 'r' }
-    )
+    readFileSync(joinPath(process.cwd(), 'package.json'), { encoding: 'utf8', flag: 'r' }),
   );
 
   // Check for environment config.
@@ -33,13 +27,10 @@ export function generateLdkSettings(): LdkSettings {
     try {
       // Need to dynamically refer to Loop's file (from cwd).
       const ldkOverrides: LdkSettings = JSON.parse(
-        readFileSync(
-          joinPath(
-            process.cwd(),
-            `ldk-config.${process.env.LDK_CONFIG}.json`,
-          ),
-          { encoding: 'utf8', flag: 'r' }
-        )
+        readFileSync(joinPath(process.cwd(), `ldk-config.${process.env.LDK_CONFIG}.json`), {
+          encoding: 'utf8',
+          flag: 'r',
+        }),
       );
       ldkSettings = mergeLdkSettings(ldkSettings, ldkOverrides);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ldk/javascript/src/webpack/generate-ldk-settings.ts
+++ b/ldk/javascript/src/webpack/generate-ldk-settings.ts
@@ -1,5 +1,7 @@
-import * as path from 'path';
+import { readFileSync } from 'fs';
+import { join as joinPath } from 'path';
 import { customizeArray, CustomizeRule, mergeWithCustomize } from 'webpack-merge';
+
 import { LdkSettings } from './ldk-settings';
 
 export function mergeLdkSettings(
@@ -15,18 +17,30 @@ export function mergeLdkSettings(
 }
 
 export function generateLdkSettings(): LdkSettings {
-  // Need to dynamically refer to Loop's package.json
-  // Suppressing rule as we intentionally want a dynamic require.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
-  let ldkSettings: LdkSettings = require(path.join(process.cwd(), '/package.json'));
+  // Need to dynamically refer to Loop's package.json (from cwd).
+  let ldkSettings: LdkSettings = JSON.parse(
+    readFileSync(
+      joinPath(
+        process.cwd(),
+        'package.json'
+      ),
+      { encoding: 'utf8', flag: 'r' }
+    )
+  );
 
+  // Check for environment config.
   if (process.env.LDK_CONFIG !== undefined) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires,import/no-dynamic-require,global-require
-      const ldkOverrides: LdkSettings = require(path.join(
-        process.cwd(),
-        `/ldk-config.${process.env.LDK_CONFIG}.json`,
-      ));
+      // Need to dynamically refer to Loop's file (from cwd).
+      const ldkOverrides: LdkSettings = JSON.parse(
+        readFileSync(
+          joinPath(
+            process.cwd(),
+            `ldk-config.${process.env.LDK_CONFIG}.json`,
+          ),
+          { encoding: 'utf8', flag: 'r' }
+        )
+      );
       ldkSettings = mergeLdkSettings(ldkSettings, ldkOverrides);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {

--- a/ldk/javascript/src/webpack/ldk-settings.ts
+++ b/ldk/javascript/src/webpack/ldk-settings.ts
@@ -63,3 +63,5 @@ export interface Ldk {
 export interface LdkSettings {
   ldk: Ldk;
 }
+
+export type LdkSettingsGenerator = () => LdkSettings

--- a/ldk/javascript/src/webpack/ldk-settings.ts
+++ b/ldk/javascript/src/webpack/ldk-settings.ts
@@ -64,4 +64,4 @@ export interface LdkSettings {
   ldk: Ldk;
 }
 
-export type LdkSettingsGenerator = () => LdkSettings
+export type LdkSettingsGenerator = () => LdkSettings;

--- a/ldk/javascript/src/webpack/shared.ts
+++ b/ldk/javascript/src/webpack/shared.ts
@@ -1,7 +1,7 @@
 import * as webpack from 'webpack';
 import Terser from 'terser-webpack-plugin';
 import path from 'path';
-import { LdkSettings } from './ldk-settings';
+import { LdkSettings, LdkSettingsGenerator } from './ldk-settings';
 import { generateBanner } from './generate-banner';
 import { buildBabelPlugins, buildBabelPreset } from './babel-config';
 import { CheckWarningsAndErrorsPlugin } from './CheckWarningsAndErrorsPlugin';
@@ -38,7 +38,7 @@ export function buildWebpackConfig(
   buildPath: string,
   baseBabelConfig: webpack.RuleSetRule,
   optimization: webpack.Configuration['optimization'],
-  ldkSettings: LdkSettings,
+  generateLdkSettings: LdkSettingsGenerator,
 ): webpack.Configuration {
   return {
     target: ['web', 'es5'],
@@ -49,7 +49,10 @@ export function buildWebpackConfig(
     mode: 'production',
     plugins: [
       new webpack.BannerPlugin({
-        banner: generateBanner(ldkSettings),
+        banner: (): string => {
+          const ldkSettings: LdkSettings = generateLdkSettings();
+          return generateBanner(ldkSettings);
+        },
         raw: true,
       }),
       new webpack.ProvidePlugin({


### PR DESCRIPTION
## [HELPS-4627](https://crosschx.atlassian.net/browse/HELPS-4627)

### Changes made:

- Main change:
    - Updated logic that reads the Loop's `package.json` to use `fs.readFileSync`/`JSON.parse` instead of `require`. `require` caches the file it reads.
    - Updated the `BannerPlugin` to use a callback for its content, rather than a string.
    - The way it worked before (using `require` and storing the result globally, passing that value into the `BannerPlugin`), it caused things like `webpack --watch` to not fully work. This is because `package.json` was read once at the start and referenced throughout. Replacing `require` and using a callback with `BannerPlugin` were both needed to fully resolve the issues around this.
- Simplified/consolidated some logic where `generateLdkSettings()` is called.
- Updated copyright year in `package.json`
