### PR TITLE
listen2 function

### DIFF
--- a/ldk/javascript/src/clipboard/clipboard.test.ts
+++ b/ldk/javascript/src/clipboard/clipboard.test.ts
@@ -4,10 +4,9 @@ import * as clipboard from '.';
 describe('Clipboard', () => {
   beforeEach(() => {
     oliveHelps.clipboard = {
-      includeOliveHelpsEvents: jest.fn(),
       read: jest.fn(),
       write: jest.fn(),
-      listen: jest.fn(),
+      listen2: jest.fn(),
     };
   });
 
@@ -41,8 +40,10 @@ describe('Clipboard', () => {
       const callback = jest.fn();
       clipboard.listen(includeOliveHelpsEvents, callback);
 
-      expect(oliveHelps.clipboard.includeOliveHelpsEvents).toHaveBeenCalledWith(
+      expect(oliveHelps.clipboard.listen2).toHaveBeenCalledWith(
         includeOliveHelpsEvents,
+        expect.any(Function),
+        expect.any(Function),
       );
     });
 
@@ -50,10 +51,8 @@ describe('Clipboard', () => {
       const callback = jest.fn();
       const text = 'abc';
       const include = true;
-      mocked(oliveHelps.clipboard.includeOliveHelpsEvents).mockImplementation((param) => {
+      mocked(oliveHelps.clipboard.listen2).mockImplementation((param, listenerCb, returnCb) => {
         expect(param).toEqual(include);
-      });
-      mocked(oliveHelps.clipboard.listen).mockImplementation((listenerCb, returnCb) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         returnCb({} as any);
         listenerCb(undefined, text);
@@ -66,7 +65,7 @@ describe('Clipboard', () => {
 
     it('rejects with the error when the underlying call throws an error', () => {
       const exception = 'Exception';
-      mocked(oliveHelps.clipboard.listen).mockImplementation(() => {
+      mocked(oliveHelps.clipboard.listen2).mockImplementation(() => {
         throw exception;
       });
 

--- a/ldk/javascript/src/clipboard/index.ts
+++ b/ldk/javascript/src/clipboard/index.ts
@@ -1,5 +1,5 @@
 import { Cancellable } from '../cancellable';
-import { promisify, promisifyListenable, promisifyWithParam } from '../promisify';
+import { promisify, promisifyWithParam, promisifyListenableWithParam} from '../promisify';
 
 /**
  *  The Clipboard aptitude provides access to the OS's clipboard.
@@ -33,8 +33,7 @@ export function listen(
   includeOliveHelpsEvents: boolean,
   callback: (clipboardText: string) => void,
 ): Promise<Cancellable> {
-  oliveHelps.clipboard.includeOliveHelpsEvents(includeOliveHelpsEvents);
-  return promisifyListenable(callback, oliveHelps.clipboard.listen);
+  return promisifyListenableWithParam(includeOliveHelpsEvents, callback, oliveHelps.clipboard.listen2);
 }
 
 export function read(): Promise<string> {

--- a/ldk/javascript/src/types/oliveHelps/clipboard.d.ts
+++ b/ldk/javascript/src/types/oliveHelps/clipboard.d.ts
@@ -4,8 +4,10 @@ declare namespace Clipboard {
 
     write: Common.ReadableWithParam<string, void>;
 
-    listen: Common.Listenable<string>;
+    // listen: Common.Listenable<string>;
 
-    includeOliveHelpsEvents(enabled: boolean): void;
+    listen2: Common.ListenableWithParam<boolean, string>;
+
+    // includeOliveHelpsEvents(enabled: boolean): void;
   }
 }


### PR DESCRIPTION
## [HELPS-4694](https://crosschx.atlassian.net/browse/HELPS-4694)

### Changes made:
- changed listen function to use listen2
- removed listen and includeOliveHelpsEvents from clipboard Aptitude


### Additional notes:
- no STL changes needed 
