### PR TITLE
removed precedence comment

### DIFF
--- a/src/whisper/types.ts
+++ b/src/whisper/types.ts
@@ -549,8 +549,7 @@ export type AutocompleteFilter = {
   /**
    * Options to configure how the filter search behaves
    *
-   * (Note: filterOptions and matchSorter can't be used together; if you include both,
-   * matchSorter will take precedence)
+   * (Note: filterOptions and matchSorter can't be used together)
    */
   filterOptions?: AutocompleteFilterOptions;
   matchSorter?: never;
@@ -560,8 +559,7 @@ export type AutocompleteMatchSorter = {
    * Options to use with our implementation of match-sorter
    * https://github.com/kentcdodds/match-sorter
    *
-   * (Note: filterOptions and matchSorter can't be used together; if you include both,
-   * matchSorter will take precedence)
+   * (Note: filterOptions and matchSorter can't be used together)
    */
   matchSorter?: AutocompleteMatchSorterOptions;
   filterOptions?: never;


### PR DESCRIPTION
## [HELPS-4739](https://crosschx.atlassian.net/browse/HELPS-4739)

### Changes made:
- removed precedence comment from autocomplete component, so its just say you can not use both matchSorter and filterOptions 
